### PR TITLE
Change the way we protect user altering controls

### DIFF
--- a/user_profiles/serializers.py
+++ b/user_profiles/serializers.py
@@ -53,8 +53,8 @@ class UserProfileSerializer(serializers.ModelSerializer):
             action_details['verb'] = 'add user'
         action_details['action_object'] = profile
         controls_to_be_added = [c for c in controls_data if c not in profile.controls.all()]
+        session_user = self.context['request'].user
         for control in controls_to_be_added:
-            session_user = self.context['request'].user
             if control not in session_user.profile.controls.all():
                 raise serializers.ValidationError(
                     f"{session_user} n'est pas authorisé à modifier ce contrôle: {control}")

--- a/user_profiles/tests/test_api.py
+++ b/user_profiles/tests/test_api.py
@@ -87,6 +87,30 @@ def test_audited_cannot_create_user():
     assert response.status_code != 201
 
 
+def test_inspector_cannot_alter_a_control_that_is_not_accessible_to_him():
+    inspector = factories.UserProfileFactory(profile_type='inspector')
+    control = factories.ControlFactory()
+    existing_user = factories.UserFactory()
+    assert control not in inspector.controls.all()
+    assert control not in existing_user.profile.controls.all()
+    post_data = {
+        'first_name': existing_user.first_name,
+        'last_name': existing_user.last_name,
+        'profile_type': 'audited',
+        'email': existing_user.email,
+        'organization': '',
+        'controls': [control.id]
+    }
+    utils.login(client, user=inspector.user)
+    url = reverse('api:user-list')
+    count_before = User.objects.count()
+    response = client.post(url, post_data)
+    count_after = User.objects.count()
+    assert response.status_code != 201
+    assert count_after == count_before
+    assert control not in existing_user.profile.controls.all()
+
+
 def test_inspector_can_remove_user_from_control():
     someone = factories.UserProfileFactory(profile_type='audited')
     inspector = factories.UserProfileFactory(profile_type='inspector')

--- a/user_profiles/tests/test_api.py
+++ b/user_profiles/tests/test_api.py
@@ -84,7 +84,7 @@ def test_audited_cannot_create_user():
     response = client.post(url, post_data)
     count_after = User.objects.count()
     assert count_after == count_before
-    assert response.status_code != 201
+    assert response.status_code >= 300
 
 
 def test_inspector_cannot_alter_a_control_that_is_not_accessible_to_him():
@@ -106,7 +106,7 @@ def test_inspector_cannot_alter_a_control_that_is_not_accessible_to_him():
     count_before = User.objects.count()
     response = client.post(url, post_data)
     count_after = User.objects.count()
-    assert response.status_code != 201
+    assert response.status_code >= 300
     assert count_after == count_before
     assert control not in existing_user.profile.controls.all()
 


### PR DESCRIPTION
Now we raise validation error when the user alters a control
he does not have access to. We use to filter out the controls,
to only list current logged in user's controls - which was too
restrictive and introduced a bug.