### PR TITLE
Questionnaire api : delete

### DIFF
--- a/control/api_views.py
+++ b/control/api_views.py
@@ -121,8 +121,9 @@ class QuestionnaireViewSet(viewsets.ModelViewSet):
             log(saved_theme)
             questions_data = theme_data.get('questions', [])
             # remove questions that aren't in request.
+            ids_in_request = [questions_data[i].get('id', None) for i in range(len(questions_data))]
             for pre_existing_question in saved_theme.questions.all():
-                if pre_existing_question.id not in set(map(lambda x: x.get('id', None), questions_data)):
+                if pre_existing_question.id not in ids_in_request:
                     pre_existing_question.delete()
             # add questions that are in request
             for question_data in questions_data:

--- a/control/api_views.py
+++ b/control/api_views.py
@@ -120,6 +120,11 @@ class QuestionnaireViewSet(viewsets.ModelViewSet):
             saved_theme = theme_ser.save(questionnaire=saved_qr)
             log(saved_theme)
             questions_data = theme_data.get('questions', [])
+            # remove questions that aren't in request.
+            for pre_existing_question in saved_theme.questions.all():
+                if pre_existing_question.id not in set(map(lambda x: x.get('id', None), questions_data)):
+                    pre_existing_question.delete()
+            # add questions that are in request
             for question_data in questions_data:
                 pre_existing_question = find_child_obj_by_id(saved_theme, question_data.get('id', None), Question)
                 question_ser = QuestionSerializer(pre_existing_question, data=question_data)

--- a/control/api_views.py
+++ b/control/api_views.py
@@ -4,7 +4,7 @@ from rest_framework import status, viewsets
 from rest_framework.exceptions import PermissionDenied
 
 from .models import Question, Questionnaire, Theme
-from .serializers import QuestionSerializer, QuestionnaireSerializer, QuestionnaireWriteSerializer, ThemeSerializer
+from .serializers import QuestionSerializer, QuestionnaireSerializer, QuestionnaireUpdateSerializer, ThemeSerializer
 
 
 class QuestionViewSet(viewsets.ReadOnlyModelViewSet):
@@ -80,7 +80,7 @@ class QuestionnaireViewSet(viewsets.ModelViewSet):
         return self.__create_or_update(request, save_questionnaire_func, is_update=True)
 
     def __validate_all(self, request, pre_existing_questionnaire=None):
-        serializer = QuestionnaireWriteSerializer(pre_existing_questionnaire, data=request.data)
+        serializer = QuestionnaireUpdateSerializer(pre_existing_questionnaire, data=request.data)
         serializer.is_valid(raise_exception=True)
 
         control = serializer.validated_data['control']

--- a/control/serializers.py
+++ b/control/serializers.py
@@ -54,9 +54,7 @@ class QuestionnaireSerializer(serializers.ModelSerializer):
         # not serialized (yet) : file, order
 
 
-
-
-class QuestionWriteSerializer(serializers.ModelSerializer):
+class QuestionUpdateSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)
 
     class Meta:
@@ -64,18 +62,17 @@ class QuestionWriteSerializer(serializers.ModelSerializer):
         fields = ('id', 'description')
 
 
-class ThemeWriteSerializer(serializers.ModelSerializer):
+class ThemeUpdateSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)
-    questions = QuestionWriteSerializer(many=True, required=False)
+    questions = QuestionUpdateSerializer(many=True, required=False)
 
     class Meta:
         model = Theme
         fields = ('id', 'title', 'questions')
-        # not serialized : order
 
 
-class QuestionnaireWriteSerializer(serializers.ModelSerializer):
-    themes = ThemeWriteSerializer(many=True, required=False)
+class QuestionnaireUpdateSerializer(serializers.ModelSerializer):
+    themes = ThemeUpdateSerializer(many=True, required=False)
 
     class Meta:
         model = Questionnaire
@@ -86,4 +83,3 @@ class QuestionnaireWriteSerializer(serializers.ModelSerializer):
                 'allow_null': False,
             }
         }
-        # not serialized (yet) : file, order

--- a/control/tests/test_api.py
+++ b/control/tests/test_api.py
@@ -388,7 +388,7 @@ def test_questionnaire_update__question_create():
 
 def test_questionnaire_update__question_create_if_bad_id():
     added_question = {
-        'id': 123,  # id is bad. It should be ignored, so that this theme is considered new.
+        'id': 123,  # id is bad. It should be ignored, so that this question is considered new.
         'description': 'this is a great question.'
     }
     run_test_questionnaire_update__question_create(added_question)
@@ -443,6 +443,58 @@ def test_questionnaire_update__question_delete():
 
     # Response data is filled in
     assert len(response.data['themes'][0].get('questions', [])) == 0
+
+
+def run_test_questionnaire_update__question_recreated(modify_payload_func):
+    increment_ids()
+    question = factories.QuestionFactory()
+    theme = question.theme
+    questionnaire = theme.questionnaire
+    user = make_user(questionnaire.control)
+    payload = make_update_payload(questionnaire)
+
+    original_id = payload['themes'][0]['questions'][0]['id']
+    modify_payload_func(payload)
+
+    assert Questionnaire.objects.all().count() == 1
+    assert Theme.objects.all().count() == 1
+    assert Question.objects.all().count() == 1
+
+    response = call_questionnaire_update_api(user, payload)
+    assert response.status_code == 200
+
+    # data is saved
+    assert Questionnaire.objects.all().count() == 1
+    assert Theme.objects.all().count() == 1
+
+    assert Question.objects.all().count() == 1
+    # Original question was deleted
+    assert Question.objects.all().last().id != original_id
+
+    # Response data is filled in
+    assert len(response.data['themes'][0].get('questions', [])) == 1
+
+
+def test_questionnaire_update__question_recreated_if_no_id():
+    def modify_payload(payload):
+        payload['themes'][0]['questions'][0].pop('id')
+
+    run_test_questionnaire_update__question_recreated(modify_payload)
+
+
+def test_questionnaire_update__question_recreated_if_bad_id():
+    bad_id = 123456
+
+    def modify_payload(payload):
+        good_id = payload['themes'][0]['questions'][0]['id']
+        assert good_id != bad_id
+        payload['themes'][0]['questions'][0]['id'] = bad_id
+
+    run_test_questionnaire_update__question_recreated(modify_payload)
+
+    # The new question has a new id.
+    assert Question.objects.all().last().id != bad_id
+
 
 
 #### Question API ####

--- a/control/tests/test_api.py
+++ b/control/tests/test_api.py
@@ -418,6 +418,33 @@ def test_questionnaire_delete():
     assert Question.objects.all().count() == 0
 
 
+def test_questionnaire_update__question_delete():
+    increment_ids()
+    question = factories.QuestionFactory()
+    theme = question.theme
+    questionnaire = theme.questionnaire
+    user = make_user(questionnaire.control)
+    payload = make_update_payload(questionnaire)
+
+    payload['themes'][0]['questions'] = []
+
+    assert Questionnaire.objects.all().count() == 1
+    assert Theme.objects.all().count() == 1
+    assert Question.objects.all().count() == 1
+
+    response = call_questionnaire_update_api(user, payload)
+    assert response.status_code == 200
+
+    # data is saved
+    assert Questionnaire.objects.all().count() == 1
+    assert Theme.objects.all().count() == 1
+
+    assert Question.objects.all().count() == 0
+
+    # Response data is filled in
+    assert len(response.data['themes'][0].get('questions', [])) == 0
+
+
 #### Question API ####
 
 def call_question_api(user, id):

--- a/control/tests/test_api.py
+++ b/control/tests/test_api.py
@@ -41,6 +41,13 @@ def call_questionnaire_update_api(user, payload):
     return response
 
 
+def call_questionnaire_delete_api(user, id):
+    utils.login(client, user=user)
+    url = reverse('api:questionnaire-detail', args=[id])
+    response = client.delete(url)
+    return response
+
+
 def make_payload(control_id):
     return {
         "title": "questionnaire questionnaire",
@@ -389,6 +396,26 @@ def test_questionnaire_update__question_create_if_bad_id():
     # Id in payload was ignored and new id was assigned to the new question
     new_question = Question.objects.last()
     assert new_question.id != added_question['id']
+
+
+def test_questionnaire_delete():
+    increment_ids()
+    question = factories.QuestionFactory()
+    theme = question.theme
+    questionnaire = theme.questionnaire
+    user = make_user(questionnaire.control)
+
+    assert Questionnaire.objects.all().count() == 1
+    assert Theme.objects.all().count() == 1
+    assert Question.objects.all().count() == 1
+
+    response = call_questionnaire_delete_api(user, questionnaire.id)
+    assert 200 <= response.status_code < 300
+
+    # Cascade delete : child objects are deleted
+    assert Questionnaire.objects.all().count() == 0
+    assert Theme.objects.all().count() == 0
+    assert Question.objects.all().count() == 0
 
 
 #### Question API ####


### PR DESCRIPTION
Quand on appelle Questionnaire update, les questions et thèmes qui sont absents du payload sont supprimés de la DB.