### PR TITLE
Show draft questionnaires to inspectors only

### DIFF
--- a/control/api_views.py
+++ b/control/api_views.py
@@ -46,6 +46,8 @@ class QuestionnaireViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         queryset = Questionnaire.objects.filter(
             control__in=self.request.user.profile.controls.all())
+        if not self.request.user.profile.is_inspector:
+            queryset = queryset.filter(is_draft=False)
         return queryset
 
     def __create_or_update(self, request, save_questionnaire_func, is_update):

--- a/control/tests/test_api.py
+++ b/control/tests/test_api.py
@@ -176,6 +176,13 @@ def test_no_modifying_questionnaire_if_not_inspector():
     assert_no_data_is_saved()
 
 
+def test_access_to_draft_if_not_inspector():
+    questionnaire = factories.QuestionnaireFactory(is_draft=True)
+    audited_user = make_audited_user(questionnaire.control)
+
+    assert call_questionnaire_detail_api(audited_user, questionnaire.id).status_code != 200
+
+
 def test_questionnaire_create__success():
     increment_ids()
     control = factories.ControlFactory()

--- a/control/tests/test_pages.py
+++ b/control/tests/test_pages.py
@@ -16,8 +16,8 @@ def make_user(profile_type, control=None):
     return user_profile.user
 
 
-def access_questionnaire_page(client, page_name, is_control_associated_with_user, profile_type):
-    questionnaire = factories.QuestionnaireFactory()
+def access_questionnaire_page(client, page_name, is_control_associated_with_user, profile_type, is_draft=False):
+    questionnaire = factories.QuestionnaireFactory(is_draft=is_draft)
     control = questionnaire.control
     if is_control_associated_with_user:
         user = make_user(profile_type, control)
@@ -49,6 +49,24 @@ def test_can_access_questionnaire_page_if_control_is_associated_with_the_user(cl
                                          is_control_associated_with_user=True,
                                          profile_type=UserProfile.AUDITED)
     assert response.status_code == 200
+
+
+def test_can_access_to_questionnaire_page_if_questionnaire_is_draft_and_user_is_inspector(client):
+    response = access_questionnaire_page(client,
+                                         page_name='questionnaire-detail',
+                                         is_control_associated_with_user=True,
+                                         profile_type=UserProfile.INSPECTOR,
+                                         is_draft=True)
+    assert response.status_code == 200
+
+
+def test_no_access_to_questionnaire_page_if_questionnaire_is_draft_and_user_is_not_inspector(client):
+    response = access_questionnaire_page(client,
+                                         page_name='questionnaire-detail',
+                                         is_control_associated_with_user=True,
+                                         profile_type=UserProfile.AUDITED,
+                                         is_draft=True)
+    assert response.status_code == 404
 
 
 def test_no_access_to_questionnaire_page_if_control_is_not_associated_with_the_user(client):

--- a/control/views.py
+++ b/control/views.py
@@ -22,29 +22,19 @@ class WithListOfControlsMixin(object):
         return context
 
 
-class QuestionnaireList(LoginRequiredMixin, WithListOfControlsMixin, ListView):
+class QuestionnaireList(LoginRequiredMixin, WithListOfControlsMixin, TemplateView):
     template_name = "ecc/questionnaire_list.html"
-    context_object_name = 'questionnaires'
-
-    def get_queryset(self):
-        return Questionnaire.objects.filter(control__in=self.request.user.profile.controls.all())
 
 
-class QuestionnaireDetail(LoginRequiredMixin, WithListOfControlsMixin, DetailView):
+class QuestionnaireDetail(LoginRequiredMixin, DetailView):
     template_name = "ecc/questionnaire_detail.html"
     context_object_name = 'questionnaire'
 
     def get_queryset(self):
-        set = Questionnaire.objects.filter(control__in=self.request.user.profile.controls.all())
+        queryset = Questionnaire.objects.filter(control__in=self.request.user.profile.controls.all())
         if not self.request.user.profile.is_inspector:
-            set = set.filter(is_draft=False)
-        return set
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        theme_list = Theme.objects.filter(questionnaire=self.object)
-        context['themes'] = theme_list
-        return context
+            queryset = queryset.filter(is_draft=False)
+        return queryset
 
 
 class QuestionnaireEdit(LoginRequiredMixin, DetailView):

--- a/control/views.py
+++ b/control/views.py
@@ -35,7 +35,10 @@ class QuestionnaireDetail(LoginRequiredMixin, WithListOfControlsMixin, DetailVie
     context_object_name = 'questionnaire'
 
     def get_queryset(self):
-        return Questionnaire.objects.filter(control__in=self.request.user.profile.controls.all())
+        set = Questionnaire.objects.filter(control__in=self.request.user.profile.controls.all())
+        if not self.request.user.profile.is_inspector:
+            set = set.filter(is_draft=False)
+        return set
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/ecc/questionnaire_detail.html
+++ b/templates/ecc/questionnaire_detail.html
@@ -61,7 +61,7 @@
             </div>
             <table class="table card-table">
               <tbody>
-              {% for theme in themes %}
+              {% for theme in questionnaire.themes.all %}
                 <tr data-id="{{ forloop.counter }}" class="theme-row">
                   <td><a href="#theme{{ theme.numbering }}">{{ theme.numbering }}. {{ theme.title }}</a></td>
                 </tr>
@@ -73,7 +73,7 @@
       </div>
     </div> <!--// closing: side_theme_list  //-->
     <div class="col-lg-8" id="questionaire-detail-app"> <!--// opening: main_list_of_questions  //-->
-      {% for theme in themes %}
+      {% for theme in questionnaire.themes.all %}
         <div class="card" id="theme{{ theme.numbering }}"> <!--// opening: theme_area_containing_questions  //-->
           <div class="card-status card-status-top bg-blue"></div>
           <div class="card-header">

--- a/templates/ecc/questionnaire_list.html
+++ b/templates/ecc/questionnaire_list.html
@@ -15,14 +15,14 @@
           <div class="card-header">
             <h4 class="page-title">{{ control.title }}</h4>
             {% if debug %}
-            {% if user.profile.is_inspector %}
-              <div class="card-options">
-                <a href="{% url 'questionnaire-create' control.id %}" class="btn btn-primary">
-                  <i class="fe fe-plus"></i>
-                  Ajouter un questionnaire
-                </a>
-              </div>
-            {% endif %}
+              {% if user.profile.is_inspector %}
+                <div class="card-options">
+                  <a href="{% url 'questionnaire-create' control.id %}" class="btn btn-primary">
+                    <i class="fe fe-plus"></i>
+                    Ajouter un questionnaire
+                  </a>
+                </div>
+              {% endif %}
             {% endif %}
           </div>
           <div class="card-body"> <!--// opening: questionnaire_description_card_body  //-->
@@ -31,53 +31,55 @@
                 <table class="table card-table table-vcenter">
                   <tbody>
                   {% for questionnaire in control.questionnaires.all %}
-                    <tr {% if questionnaire.is_draft %} class="draft" {% endif %}>
-                      <td>
-                        <h5>
-                          {% if questionnaire.is_draft %} <span>[Brouillon]</span> {% endif %}
-                          <span>{{ questionnaire.title }}</span>
-                        </h5>
-                        {% if questionnaire.sent_date %}
-                          <div><i class="fe fe-send"></i> Date de transmission du questionnaire :
-                            {{ questionnaire.sent_date|date:"l d F Y" }}
-                          </div>
-                        {% endif %}
-                        {% if questionnaire.end_date %}
-                          <div><i class="fe fe-clock"></i> Date de réponse souhaitée :
-                            {{ questionnaire.end_date|date:"l d F Y" }}
-                          </div>
-                        {% endif %}
-                      </td>
-                      <td class="w-1">
-                        {% if user.profile.is_audited %}
-                          <a href="{{ questionnaire.url }}"
-                             class="btn btn-primary"
-                             title="Déposer et consulter vos réponses"
-                          >
-                            <i class="fe fe-eye"></i>
-                            Répondre
-                          </a>
-                        {% elif user.profile.is_inspector %}
-                          {% if questionnaire.is_draft %}
-                            <a href="{% url 'questionnaire-edit' questionnaire.id %}"
-                               class="btn btn-primary"
-                               title="Modifier le brouillon de questionnaire"
-                            >
-                              <i class="fe fe-edit"></i>
-                              Modifier
-                            </a>
-                          {% else %}
+                    {% if user.profile.is_inspector or not questionnaire.is_draft %}
+                      <tr {% if questionnaire.is_draft %} class="draft" {% endif %}>
+                        <td>
+                          <h5>
+                            {% if questionnaire.is_draft %} <span>[Brouillon]</span> {% endif %}
+                            <span>{{ questionnaire.title }}</span>
+                          </h5>
+                          {% if questionnaire.sent_date %}
+                            <div><i class="fe fe-send"></i> Date de transmission du questionnaire :
+                              {{ questionnaire.sent_date|date:"l d F Y" }}
+                            </div>
+                          {% endif %}
+                          {% if questionnaire.end_date %}
+                            <div><i class="fe fe-clock"></i> Date de réponse souhaitée :
+                              {{ questionnaire.end_date|date:"l d F Y" }}
+                            </div>
+                          {% endif %}
+                        </td>
+                        <td class="w-1">
+                          {% if user.profile.is_audited %}
                             <a href="{{ questionnaire.url }}"
                                class="btn btn-primary"
-                               title="Consulter les réponses sur E-contrôle"
+                               title="Déposer et consulter vos réponses"
                             >
                               <i class="fe fe-eye"></i>
-                              Consulter
+                              Répondre
                             </a>
+                          {% elif user.profile.is_inspector %}
+                            {% if questionnaire.is_draft %}
+                              <a href="{% url 'questionnaire-edit' questionnaire.id %}"
+                                 class="btn btn-primary"
+                                 title="Modifier le brouillon de questionnaire"
+                              >
+                                <i class="fe fe-edit"></i>
+                                Modifier
+                              </a>
+                            {% else %}
+                              <a href="{{ questionnaire.url }}"
+                                 class="btn btn-primary"
+                                 title="Consulter les réponses sur E-contrôle"
+                              >
+                                <i class="fe fe-eye"></i>
+                                Consulter
+                              </a>
+                            {% endif %}
                           {% endif %}
-                        {% endif %}
-                      </td>
-                    </tr>
+                        </td>
+                      </tr>
+                    {% endif %}
                   {% endfor %}
                   </tbody>
                 </table>


### PR DESCRIPTION
Restrict access to drafts in :
 - API access to get draft questionnaire
- page to view draft (questionnaire-detail)
 - Accueil page : don't display non-drafts

And some cleaning up of the views : removed unneeded inheritance.