### PR TITLE
Bugfix : trashed files reappear

### DIFF
--- a/static/src/questions/ResponseDropzone.vue
+++ b/static/src/questions/ResponseDropzone.vue
@@ -26,6 +26,7 @@
   import Dropzone from 'dropzone'
   import EventBus from '../events'
   import InfoBar from '../utils/InfoBar'
+  import { clearCache } from '../utils/utils'
 
   import axios from 'axios'
 
@@ -76,6 +77,7 @@
     },
     methods: {
       dropzoneSuccessCallback: function() {
+        clearCache()
         this.fetchQuestionData().then(response_files => {
           EventBus.$emit('response-files-updated-' + this.questionId, response_files);
         })

--- a/static/src/questions/ResponseFileList.vue
+++ b/static/src/questions/ResponseFileList.vue
@@ -115,6 +115,11 @@
         this.files.splice(index, 1)
         return file
       },
+      clearCache: function() {
+        // Change the url (by adding a random querystring value) to force reload on next visit, because the
+        // questionnaire data has changed. (it doesn't actually change the browser cache for the current url)
+        history.pushState({}, "", "?reload=" + Math.random())
+      },
       sendToTrash: function(fileId) {
         let formData = new FormData()
         formData.append('is_deleted', true)
@@ -127,6 +132,7 @@
           }
         ).then(response =>{
           console.debug('success deleting response file', response.data)
+          this.clearCache()
           const removedFile = this.removeFileFromList(response.data.id)
           this.sendUpdateEvent()
           this.message = `Le fichier "${removedFile.basename}" a bien été envoyé à la corbeille.

--- a/static/src/questions/ResponseFileList.vue
+++ b/static/src/questions/ResponseFileList.vue
@@ -56,6 +56,7 @@
   import Vue from "vue";
 
   import axios from 'axios'
+  import { clearCache } from '../utils/utils'
   import ConfirmModal from '../utils/ConfirmModal'
   import ErrorBar from '../utils/ErrorBar'
   import EventBus from '../events'
@@ -115,11 +116,6 @@
         this.files.splice(index, 1)
         return file
       },
-      clearCache: function() {
-        // Change the url (by adding a random querystring value) to force reload on next visit, because the
-        // questionnaire data has changed. (it doesn't actually change the browser cache for the current url)
-        history.pushState({}, "", "?reload=" + Math.random())
-      },
       sendToTrash: function(fileId) {
         let formData = new FormData()
         formData.append('is_deleted', true)
@@ -132,7 +128,7 @@
           }
         ).then(response =>{
           console.debug('success deleting response file', response.data)
-          this.clearCache()
+          clearCache()
           const removedFile = this.removeFileFromList(response.data.id)
           this.sendUpdateEvent()
           this.message = `Le fichier "${removedFile.basename}" a bien été envoyé à la corbeille.

--- a/static/src/utils/utils.js
+++ b/static/src/utils/utils.js
@@ -1,0 +1,7 @@
+
+
+export const clearCache = function() {
+  // Change the url (by adding a random querystring value) to force reload on next visit, because the
+  // questionnaire data has changed. (it doesn't actually change the browser cache for the current url)
+  history.pushState({}, "", "?reload=" + Math.random())
+}


### PR DESCRIPTION
Bug : 
- reload the questionnaire_detail page (/questionnaire/<id>/)
- trash a response file
- go to another page (e.g. trash page)
- use browser's back button to go back to questionnaire_detail page : the file appears un-trashed.

This is because the questionnaire object is passed in the django template by the server, as part of the html. So when the browser loads the page from cache, it reloads the old version of the questionnaire object alors with the response files.

The same bug happens when adding a response file.

Fix : add a random querystring to the url, so that the page is reloaded forreal on next visit (the browser thinks it's a different page because of the querystring and reloads it)