### PR TITLE
Corbeille : renommer le fichier webdav du doc supprimé

### DIFF
--- a/control/api_views.py
+++ b/control/api_views.py
@@ -118,16 +118,8 @@ class ResponseFileTrash(mixins.UpdateModelMixin, generics.GenericAPIView):
                 # un-trash : not implemented yet
                 raise serializers.ValidationError('Vous ne pouvez sortir un fichier réponse de la corbeille.')
 
-        '''
-        instance.file.name = instance.file.name + ResponseFileTrash.trashed_file_prefix
-        instance.save()
-        import ipdb
-        ipdb.set_trace()
-        '''
-        deleted_file = File(instance.file, name=ResponseFileTrash.trashed_file_prefix + instance.basename)
-        '''
-        os.rename(instance.file.path, instance.file.path + ResponseFileTrash.trashed_file_prefix)
-        '''
+        deleted_file = File(instance.file, name=instance.basename)
+        serializer.save(file=deleted_file)
 
         # Log deletion action (including re-deleting)
         if serializer.validated_data['is_deleted']:
@@ -137,8 +129,6 @@ class ResponseFileTrash(mixins.UpdateModelMixin, generics.GenericAPIView):
                 'target': instance,
             }
             action.send(**action_details)
-
-        serializer.save(file=deleted_file)
 
 
 class ThemeViewSet(viewsets.ModelViewSet):

--- a/control/api_views.py
+++ b/control/api_views.py
@@ -118,6 +118,7 @@ class ResponseFileTrash(mixins.UpdateModelMixin, generics.GenericAPIView):
                 # un-trash : not implemented yet
                 raise serializers.ValidationError('Vous ne pouvez sortir un fichier réponse de la corbeille.')
 
+        # Save a new file, that gets uploaded to the deleted files path.
         deleted_file = File(instance.file, name=instance.basename)
         serializer.save(file=deleted_file)
 
@@ -129,6 +130,9 @@ class ResponseFileTrash(mixins.UpdateModelMixin, generics.GenericAPIView):
                 'target': instance,
             }
             action.send(**action_details)
+
+        # Delete file left at old path
+        instance.file.delete(False)
 
 
 class ThemeViewSet(viewsets.ModelViewSet):

--- a/control/models.py
+++ b/control/models.py
@@ -246,6 +246,8 @@ class ResponseFile(TimeStampedModel):
         """
         Remove the suffix found in filename 'Q01-T02-01-'.
         """
+        if self.is_deleted:
+            return re.sub(r'CORBEILLE-Q\d+-T\d+-\d+-', '', basename)
         return re.sub(r'Q\d+-T\d+-\d+-', '', basename)
 
     @property

--- a/control/tests/test_api_response_file.py
+++ b/control/tests/test_api_response_file.py
@@ -133,6 +133,21 @@ def test_trashing_logs_an_action():
     assert action.target_object_id == str(response_file.id)
 
 
+def test_trashing_moves_the_file_on_disk():
+    response_file = factories.ResponseFileFactory()
+    user = utils.make_audited_user(response_file.question.theme.questionnaire.control)
+    payload = { "is_deleted": "true" }
+
+    path_before = response_file.file.path
+    assert 'CORBEILLE' not in path_before
+
+    trash_response_file(user, response_file.id, payload)
+
+    path_after = ResponseFile.objects.get(id=response_file.id).file.path
+    assert path_after != path_before
+    assert 'CORBEILLE' in path_after
+
+
 def test_can_retrash_a_trashed_file():
     response_file = factories.ResponseFileFactory(is_deleted=True)
     user = utils.make_audited_user(response_file.question.theme.questionnaire.control)

--- a/control/upload_path.py
+++ b/control/upload_path.py
@@ -39,6 +39,12 @@ class PathBuilder(object):
         path = f'{self.theme_path}/{response_filename}'
         return path
 
+    def get_deleted_response_file_path(self):
+        prefix = f'CORBEILLE-Q{self.questionaire_num:02}-T{self.theme_num:02}-{self.question_num:02}'
+        response_filename = f'{prefix}-{self.filename}'
+        path = f'{self.theme_path}/{response_filename}'
+        return path
+
 
 def question_file_path(instance, filename):
     path = PathBuilder(file_object=instance, filename=filename)
@@ -47,4 +53,6 @@ def question_file_path(instance, filename):
 
 def response_file_path(instance, filename):
     path = PathBuilder(file_object=instance, filename=filename)
+    if instance.is_deleted:
+        return path.get_deleted_response_file_path()
     return path.get_response_file_path()


### PR DESCRIPTION
Pour le moment, on ajoute CORBEILLE- devant le nom, et on laisse le fichier dans le meme dossier. 
On va tester en openlab pour recueillir des avis sur le dossier corbeille et le nom du fichier.

![Screenshot 2019-09-03 at 15 03 35](https://user-images.githubusercontent.com/911434/64175709-2683dd80-ce5c-11e9-82d4-eeedef6bd428.png)
