### PR TITLE
Put the multicolored colorBar back

### DIFF
--- a/templates/ecc/questionnaire_list.html
+++ b/templates/ecc/questionnaire_list.html
@@ -16,7 +16,7 @@
 
       {% for control in controls reversed %}
         <div class="card" id="control-{{ control.id }}">
-          <div class="card-status card-status-left bg-blue"></div>
+          <color-bar id="{{ control.id }}"></color-bar>
           <div class="card-header">
             <control-title :control="{{ control.data }}" :key={{ control.id }}></control-title>
           </div>


### PR DESCRIPTION
Put the multicolored colorBar back on the side of Spaces : 
![Screenshot 2019-10-03 at 13 40 04](https://user-images.githubusercontent.com/911434/66123916-62d56580-e5e3-11e9-83aa-366c27d87dd8.png)

We'll get rid of it once we have better navigation.