### PR TITLE
Questionnaire default description disappeared

### DIFF
--- a/static/src/questionnaires/QuestionnaireBodyCreate.vue
+++ b/static/src/questionnaires/QuestionnaireBodyCreate.vue
@@ -184,6 +184,9 @@
         // Empty old themes
         this.body = []
         // Replace with new themes
+        if (!data.themes) {
+          return
+        }
         data.themes.forEach(theme => {
           console.debug('theme', theme)
           this.body.push(theme)

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -94,6 +94,7 @@
   import moment from "moment"
   import QuestionnaireBodyCreate from "./QuestionnaireBodyCreate"
   import QuestionnaireMetadataCreate from "./QuestionnaireMetadataCreate"
+  import { DESCRIPTION_DEFAULT } from "./QuestionnaireMetadataCreate"
   import QuestionnairePreview from "./QuestionnairePreview"
   import Vue from "vue"
 
@@ -159,6 +160,7 @@
     methods: {
       _loadQuestionnaireCreate: function() {
         this.questionnaire.control = this.controlId
+        this.questionnaire.description = DESCRIPTION_DEFAULT
         this.emitQuestionnaireUpdated()
         console.debug('loaded new questionnaire', this.questionnaire)
         this.moveToState(STATES.START)

--- a/static/src/questionnaires/QuestionnaireMetadataCreate.vue
+++ b/static/src/questionnaires/QuestionnaireMetadataCreate.vue
@@ -79,7 +79,7 @@
   import reportValidity from 'report-validity';
 
 
-  let DESCRIPTION_DEFAULT = "À l’occasion de ce contrôle, \
+  export let DESCRIPTION_DEFAULT = "À l’occasion de ce contrôle, \
 je vous demande de me transmettre des renseignements et des justifications \
 sur les points énumérés dans ce questionnaire.\nVous voudrez bien me faire \
 parvenir au fur et à mesure votre réponse. \
@@ -93,7 +93,7 @@ services pour toute information complémentaire qu’appellerait ce questionnair
     data() {
       return {
         metadata: {
-            'description': DESCRIPTION_DEFAULT,
+            'description': '',
             'end_date': '',
             'title': ''
         },


### PR DESCRIPTION
Bug : create a new questionnaire in UI. The default description is not there.

It had disappeared because the first loading of the questionnaire had changed.

Now the default description is set by QuestionnaireCreate, before sending it out to child components.