### PR TITLE
Cleanup : retirer django-filer

### DIFF
--- a/control/migrations/0001_initial.py
+++ b/control/migrations/0001_initial.py
@@ -2,17 +2,14 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-import filer.fields.file
 import mptt.fields
+
+import control.upload_path
 
 
 class Migration(migrations.Migration):
 
     initial = True
-
-    dependencies = [
-        ('filer', '0010_auto_20180414_2058'),
-    ]
 
     operations = [
         migrations.CreateModel(
@@ -44,7 +41,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('order', models.PositiveIntegerField(db_index=True, editable=False, verbose_name='order')),
-                ('file', filer.fields.file.FilerFileField(on_delete=django.db.models.deletion.CASCADE, to='filer.File', verbose_name='fichier')),
+                ('file', models.FileField(default='', upload_to=control.upload_path.question_file_path, verbose_name='fichier')),
                 ('question', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='files', to='control.Question', verbose_name='question')),
             ],
             options={

--- a/ecc/settings.py
+++ b/ecc/settings.py
@@ -42,7 +42,6 @@ INSTALLED_APPS = [
     'debug_toolbar',
     'model_utils',
     'easy_thumbnails',
-    'filer',
     'ordered_model',
     'django_extensions',
     'actstream',

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ psycopg2-binary==2.8.3
 Jinja2==2.10.1
 uwsgi==2.0.18
 django-model-utils==3.2.0
-django-filer==1.5.0
 django-ordered-model==3.3.0
 django-environ==0.4.5
 pytest==4.6.4


### PR DESCRIPTION
We want to remove django-filer that's not used anymore.
For that, we have to remove historical references to that app
in migration history. So we hack the migration history  to avoid
importing this app.