### PR TITLE
No Add Space button for audited users

### DIFF
--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -12,7 +12,7 @@
       </div>
     </div>
 
-    <div class="card-header flex-row justify-content-center">
+    <div v-if="user.is_inspector" class="card-header flex-row justify-content-center">
       <control-create></control-create>
     </div>
 


### PR DESCRIPTION
Fix for 1.9 release. 
Also fixes a bug where the Add Space button appears on the TOS page.