### PR TITLE
Allow accented characters in reference_code

### DIFF
--- a/static/src/controls/ControlCreate.vue
+++ b/static/src/controls/ControlCreate.vue
@@ -56,9 +56,9 @@
               <span class="input-group-text">{{ reference_code_prefix }}</span>
             </span>
               <input type="text" class="form-control" v-model="reference_code_suffix" required
-                     pattern="^[\.\s\w-]+$"
+                     pattern="^[\.\s\wÀ-ÖØ-öø-ÿŒœ-]+$"
                      maxlength="255"
-                     title="Ce champ ne doit pas contenir d'accents (é, à, è, ...) ou de caractères spéciaux (! , @ # $ / \...)"
+                     title="Ce champ ne doit pas contenir de caractères spéciaux ( ! , @ # $ / \ ' &quot; + etc)"
                      aria-describedby="reference-code-help">
             </div>
           </div>
@@ -130,7 +130,7 @@
           }
           if (error.response.data['reference_code'][0] === 'INVALID') {
             return 'Le nom abrégé "' + requestedCode +
-                '" ne doit pas contenir d'accents (é, à, è...) ou de caractères spéciaux ("! , @ # $ / \\".' +...).'
+                '" ne doit pas contenir de caractères spéciaux (! , @ # $ / \\ " \' + etc).'
                 ' Veuillez en choisir un autre.'
           }
         }

--- a/static/src/controls/ControlCreate.vue
+++ b/static/src/controls/ControlCreate.vue
@@ -58,7 +58,7 @@
               <input type="text" class="form-control" v-model="reference_code_suffix" required
                      pattern="^[\.\s\w-]+$"
                      maxlength="255"
-                     title="Ce champ ne doit pas contenir de caractères spéciaux tels que ! , @ # $ / \"
+                     title="Ce champ ne doit pas contenir d'accents (é, à, è, ...) ou de caractères spéciaux (! , @ # $ / \...)"
                      aria-describedby="reference-code-help">
             </div>
           </div>
@@ -130,7 +130,7 @@
           }
           if (error.response.data['reference_code'][0] === 'INVALID') {
             return 'Le nom abrégé "' + requestedCode +
-                '" ne doit pas contenir de caractères spéciaux tels que "! , @ # $ / \\".' +
+                '" ne doit pas contenir d'accents (é, à, è...) ou de caractères spéciaux ("! , @ # $ / \\".' +...).'
                 ' Veuillez en choisir un autre.'
           }
         }


### PR DESCRIPTION
Update error response if there is accent in code référence.

Message d'un contrôleur : 
Bonjour,

Je démarre un contrôle (Juridictionnel lycée Bertran de Born à Périgueux ) avec e-contrôle. 

Ne faudrait-il pas préciser dans la bulle d’information de la case où il faut rentrer un libellé abrégé du contrôle que les accents ne sont pas admis. J’ai eu quelques difficultés avec cela. Il me refusait le nom sans préciser pourquoi.

Sinon, tout va bien. Cela parait très ergonomique et pratique. Je compléterai encore le questionnaire avant de l’envoyer au contrôlé.

Bien cordialement