### PR TITLE
1.10 fixes

### DIFF
--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -45,11 +45,13 @@
         {{ message }}
       </div>
     </div>
-    <a :href="homeUrl + '#control-' + questionnaire.control"
-       class="btn btn-secondary"
-       style="position:relative; bottom: 151px; left: 2em;">
+    <button type="button"
+            class="btn btn-secondary"
+            style="position:relative; bottom: 151px; left: 2em;"
+            @click="goHome"
+    >
       < Revenir à l'accueil
-    </a>
+    </button>
 
     <empty-modal id="savingModal" ref="savingModal" no-close="true">
       <div class="d-flex flex-column align-items-center p-8">
@@ -127,7 +129,6 @@ export default Vue.extend({
       questionnaire: {},
       state: '',
       message: '',
-      homeUrl: backend.home,
     }
   },
   components: {
@@ -335,7 +336,7 @@ export default Vue.extend({
       // has been registered.
       $(event.target).addClass('btn-loading')
 
-      window.location.href = backend.home + '#control-' + this.questionnaire.control
+      window.location.href = backend['control-detail'](this.questionnaire.control)
     },
   },
 })

--- a/static/src/questionnaires/QuestionnaireMetadataCreate.vue
+++ b/static/src/questionnaires/QuestionnaireMetadataCreate.vue
@@ -72,33 +72,32 @@
 </template>
 
 <script>
-  import Vue from "vue";
-  import Datepicker from 'vuejs-datepicker';
+  import Vue from "vue"
+  import Datepicker from 'vuejs-datepicker'
   import Wizard from "../utils/Wizard"
   import fr from "../utils/vuejs-datepicker-locale-fr"
-  import reportValidity from 'report-validity';
+  import reportValidity from 'report-validity'
 
-
-  export let DESCRIPTION_DEFAULT = "À l’occasion de ce contrôle, \
+  const DESCRIPTION_DEFAULT = "À l’occasion de ce contrôle, \
 je vous demande de me transmettre des renseignements et des justifications \
 sur les points énumérés dans ce questionnaire.\nVous voudrez bien me faire \
 parvenir au fur et à mesure votre réponse. \
 \nJe reste à votre disposition ainsi qu’à celle de vos \
-services pour toute information complémentaire qu’appellerait ce questionnaire.";
+services pour toute information complémentaire qu’appellerait ce questionnaire."
 
-  export default Vue.extend({
+  const QuestionnaireMetadataCreate = Vue.extend({
     props: {
-      questionnaireNumbering: Number
+      questionnaireNumbering: Number,
     },
     data() {
       return {
         metadata: {
-            'description': '',
-            'end_date': '',
-            'title': ''
+          description: '',
+          end_date: '',
+          title: '',
         },
-        'errors': [],
-        'fr': fr // locale for datepicker
+        errors: [],
+        fr: fr, // locale for datepicker
       }
     },
     mounted() {
@@ -108,12 +107,12 @@ services pour toute information complémentaire qu’appellerait ce questionnair
           console.debug('key', key)
           this.$set(this.metadata, key, data[key])
         }
-      }.bind(this);
+      }.bind(this)
 
       this.$parent.$on('questionnaire-updated', function(data) {
-        console.debug('new metadata', data);
-        loadMetadata(data);
-      });
+        console.debug('new metadata', data)
+        loadMetadata(data)
+      })
     },
     methods: {
       validateForm: function() {
@@ -138,8 +137,12 @@ services pour toute information complémentaire qu’appellerait ce questionnair
     components: {
       Datepicker,
       Wizard,
-    }
-  });
+    },
+  })
+
+  QuestionnaireMetadataCreate.DESCRIPTION_DEFAULT = DESCRIPTION_DEFAULT
+  export default QuestionnaireMetadataCreate
+
 </script>
 
 <style></style>


### PR DESCRIPTION
 - Le texte type dans l'introduction d'un questionnaire a disparu du mode brouillon 
 - quand on publie un questionnaire, il y a un pop-up. Il propose un bouton "revenir à l'accueil". Quand on clic on tombe sur une page d'erreur 
 - les boutons retour dans la creation de questionnaire etaient aussi cassés, pour la meme raison
