### PR TITLE
Release notes : link to the file from the tagged commit

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -8,7 +8,7 @@
       </div>
       <div class="flex-grow">
         e-contrôle
-        <a href='https://github.com/betagouv/e-controle/blob/develop/docs/releases/1.10.md'>v1.10 beta</a>
+        <a href='https://github.com/betagouv/e-controle/blob/1.10/docs/releases/1.10.md'>v1.10 beta</a>
       </span>
     </div>
     <div class="text-center">


### PR DESCRIPTION
Since the released code is the one in the tagged commit, it makes more sense to link to the release notes from the same tagged commit (instead of develop)