### PR TITLE
Update "aucun utilisateur trouvé"

### DIFF
--- a/adauth/auth.py
+++ b/adauth/auth.py
@@ -16,7 +16,7 @@ def active_directory_auth(user_email=None):
         # We now create the user if it is authorized
         create_user(user_info)
     else:
-        raise forms.ValidationError(f"Aucun utilisateur trouvé")
+        raise forms.ValidationError(f"Aucun utilisateur trouvé. Vérifiez l'orthographe de l'email renseigné ou assurez-vous que l'équipe de contrôle vous a bien ajouté à un espace de dépôt")
 
 
 def get_user_form_ad(user_email):

--- a/adauth/auth.py
+++ b/adauth/auth.py
@@ -16,7 +16,7 @@ def active_directory_auth(user_email=None):
         # We now create the user if it is authorized
         create_user(user_info)
     else:
-        raise forms.ValidationError(f"Aucun utilisateur trouvé. Vérifiez l'orthographe de l'email renseigné ou assurez-vous que l'équipe de contrôle vous a bien ajouté à un espace de dépôt")
+        raise forms.ValidationError(f"Aucun utilisateur trouvé. Vérifiez l'orthographe de l'email renseigné ou assurez-vous que l'équipe de contrôle vous a bien ajouté à un espace de dépôt.")
 
 
 def get_user_form_ad(user_email):

--- a/templates/login/login.html
+++ b/templates/login/login.html
@@ -51,7 +51,7 @@
                         placeholder="Votre email professionnel"
                         required />
                   {% for error in form.email.errors %}
-                    <div class="alet alert-danger text-center">
+                    <div class="alert alert-danger text-center">
                       {{ error }}
                     </div>
                   {% endfor %}


### PR DESCRIPTION
Si un utilisateur (organisme contrôlé), réellement invité, essaie de se connecter mais qu'il voit ce message d'erreur "aucun utilisateur trouvé", il peut y avoir deux explications : email mal orthographié ou l'équipe de contrôle a oublié de l'ajouter à l'espace de dépôt ou mal orthographié.
Au lieu de passer par le support e.contrôle pour faire ces vérifications, autant raccourcir le circuit en les invitants à vérifier ces deux éléments.