### PR TITLE
Display Datepicker in front of footer

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -95,7 +95,7 @@
     left: 0px;
     width: 100%;
     height: 140px;
-    z-index: 999;
+    z-index: 99;
 }
 
 .big-icon {


### PR DESCRIPTION
Datepicker is hidden behind footer. 
Solving https://github.com/betagouv/e-controle/issues/384