### PR TITLE
Save draft before swapping editor

### DIFF
--- a/static/src/editors/SwapEditorButton.vue
+++ b/static/src/editors/SwapEditorButton.vue
@@ -9,8 +9,7 @@
         <button type="submit"
           class="btn btn-primary"
           title="Transférer les droits de rédaction..."
-          data-toggle="modal"
-          data-target="#swapEditorModal">
+          @click="saveDraft">
           <i class="fa fa-exchange-alt mr-1"></i>
           Transférer les droits de rédaction...
         </button>
@@ -38,6 +37,16 @@ export default Vue.extend({
   components: {
     SwapEditorModal,
     SwapEditorSuccessModal,
+  },
+  mounted: function() {
+    this.$parent.$on('show-swap-editor-modal', function(data) {
+      $('#swapEditorModal').modal('show')
+    })
+  },
+  methods: {
+    saveDraft: function() {
+      this.$emit('save-draft')
+    },
   },
 })
 </script>

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -1,7 +1,8 @@
 <template>
   <div>
     <swap-editor-button :control-id='controlId'
-                        :questionnaire-id='questionnaireId'>
+                        :questionnaire-id='questionnaireId'
+                        @save-draft="saveDraftBeforeEditorSwap">
     </swap-editor-button>
 
     <div class="page-header">
@@ -291,6 +292,34 @@ export default Vue.extend({
     saveDraftFromBody(data) {
       this._updateBody(data)
       this.saveDraft()
+    },
+    saveDraftBeforeEditorSwap() {
+      console.debug('save draft before editor swap')
+      const validateForm = () => {
+        if (this.state === STATES.PREVIEW) {
+          return true
+        }
+        if (this.state === STATES.START) {
+          return this.$refs.createMetadataChild.validateForm()
+        }
+        if (this.state === STATES.CREATING_BODY) {
+          return this.$refs.createBodyChild.validateForm()
+        }
+      }
+      const updateQuestionnaire = () => {
+        if (this.state === STATES.START) {
+          this._updateMetadata(this.$refs.createMetadataChild.metadata)
+        } else if (this.state === STATES.CREATING_BODY) {
+          this._updateBody(this.$refs.createBodyChild.body)
+        }
+      }
+
+      if (!validateForm()) {
+        return
+      }
+      updateQuestionnaire()
+      this.saveDraft()
+      this.$emit('show-swap-editor-modal')
     },
     saveDraft() {
       this.questionnaire.is_draft = true

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -333,7 +333,8 @@ export default Vue.extend({
         })
         .catch((error) => {
           console.error(error)
-          this.displayErrors('Erreur lors de la sauvegarde du brouillon.', error.response.data)
+          const errorToDisplay = (error.response && error.response.data) ? error.response.data : error
+          this.displayErrors('Erreur lors de la sauvegarde du brouillon.', errorToDisplay)
         })
     },
     wait(timeMillis) {


### PR DESCRIPTION
New flow : 
 - User wants to give up editing rights, and clicks the SwapEditorButton
 - The SwapEditorButton, instead of displaying the modal, will send a 'save-draft' event to its parent, QuestionnaireCreate.
 - QuestionnaireCreate checks that the questionnaire is saveable by validating the form. 
 - It its isn't saveable, abort. If it is, QuestionnaireCreate does the save, then sends event 'show-swap-editor-modal' to SwapEditorButton
 - SwapEditorButton shows the modal. 
 - < same flow from then on >

In the case that the draft is saveable, but the save fails (network problems, server error...), an error is displayed and the modal opens anyway.