### PR TITLE
Case where there is no editor for a questionnaire

### DIFF
--- a/static/src/editors/RequestEditorButton.vue
+++ b/static/src/editors/RequestEditorButton.vue
@@ -12,11 +12,21 @@
         </span>
       </div>
       <div class="text-right">
-        <button type="submit"
+        <button v-if="questionnaire.editor"
+          type="submit"
           class="btn btn-gray"
           title="Obtenir les droits de rédaction..."
           data-toggle="modal"
           data-target="#requestEditorModal">
+          <i class="fa fa-exchange-alt mr-1"></i>
+          <span>Obtenir les droits de rédaction...</span>
+        </button>
+        <button v-else
+          type="submit"
+          class="btn btn-gray"
+          title="Obtenir les droits de rédaction..."
+          @click="switchToEditorPage"
+          >
           <i class="fa fa-exchange-alt mr-1"></i>
           <span>Obtenir les droits de rédaction...</span>
         </button>
@@ -28,15 +38,39 @@
 </template>
 
 <script>
-import Vue from 'vue'
+import backendUrls from '../utils/backend.js'
 import BecomeEditorModal from '../editors/BecomeEditorModal'
+import { mapFields } from 'vuex-map-fields'
 import RequestEditorModal from '../editors/RequestEditorModal'
+import Vue from 'vue'
 
 export default Vue.extend({
   props: ['questionnaire'],
   components: {
     RequestEditorModal,
     BecomeEditorModal,
+  },
+  computed: {
+    ...mapFields(['sessionUser']),
+  },
+  methods: {
+    callSwapEditorApi(editorUser, questionnaireId) {
+      const url = '/api' + backendUrls['swap-editor'](questionnaireId)
+      return Vue.axios.put(url, {
+        editor: editorUser,
+      })
+    },
+    switchToEditorPage: function() {
+      this.callSwapEditorApi(this.sessionUser.id, this.questionnaire.id)
+        .then((response) => {
+          console.debug('got editing rights', response)
+          window.location.assign(backendUrls['questionnaire-edit'](this.questionnaire.id))
+        })
+        .catch(error => {
+          console.error(error)
+          // todo handle error
+        })
+    },
   },
 })
 </script>

--- a/static/src/editors/RequestEditorButton.vue
+++ b/static/src/editors/RequestEditorButton.vue
@@ -33,8 +33,8 @@
           </button>
         </div>
       </div>
-      <error-bar class="mt-4">
-        bli
+      <error-bar v-if="errorMessage.length > 0" class="mt-4">
+        {{ errorMessage }}
       </error-bar>
     </div>
     <request-editor-modal id="requestEditorModal" :questionnaire='questionnaire'></request-editor-modal>
@@ -52,6 +52,11 @@ import Vue from 'vue'
 
 export default Vue.extend({
   props: ['questionnaire'],
+  data: function() {
+    return {
+      errorMessage: '',
+    }
+  },
   components: {
     BecomeEditorModal,
     ErrorBar,
@@ -68,6 +73,7 @@ export default Vue.extend({
       })
     },
     switchToEditorPage: function() {
+      this.errorMessage = ''
       this.callSwapEditorApi(this.sessionUser.id, this.questionnaire.id)
         .then((response) => {
           console.debug('got editing rights', response)
@@ -75,7 +81,7 @@ export default Vue.extend({
         })
         .catch(error => {
           console.error(error)
-          // todo handle error
+          this.errorMessage = 'Erreur lors de l\'obtention des droits. Vous pouvez réessayer.'
         })
     },
   },

--- a/static/src/editors/RequestEditorButton.vue
+++ b/static/src/editors/RequestEditorButton.vue
@@ -1,36 +1,41 @@
 <template>
   <div>
-    <div class="alert alert-secondary flex-row justify-content-between" role="alert">
-      <div class="mt-2">
-        <i class="fe fe-users mr-1"></i>
-        <span v-if="questionnaire.editor">
-          <strong>{{ questionnaire.editor.first_name }} {{ questionnaire.editor.last_name }}</strong>
-          est actuellement la seule personne qui peut modifier ce questionnaire
-        </span>
-        <span v-else>
-          Personne n'est actuellement affecté à la rédaction de ce questionnaire.
-        </span>
+    <div class="alert alert-secondary" role="alert">
+      <div class="flex-row justify-content-between align-items-center">
+        <div>
+          <i class="fe fe-users mr-1"></i>
+          <span v-if="questionnaire.editor">
+            <strong>{{ questionnaire.editor.first_name }} {{ questionnaire.editor.last_name }}</strong>
+            est actuellement la seule personne qui peut modifier ce questionnaire
+          </span>
+          <span v-else>
+            Personne n'est actuellement affecté à la rédaction de ce questionnaire.
+          </span>
+        </div>
+        <div class="text-right">
+          <button v-if="questionnaire.editor"
+            type="submit"
+            class="btn btn-gray"
+            title="Obtenir les droits de rédaction..."
+            data-toggle="modal"
+            data-target="#requestEditorModal">
+            <i class="fa fa-exchange-alt mr-1"></i>
+            <span>Obtenir les droits de rédaction...</span>
+          </button>
+          <button v-else
+            type="submit"
+            class="btn btn-gray"
+            title="Obtenir les droits de rédaction..."
+            @click="switchToEditorPage"
+            >
+            <i class="fa fa-exchange-alt mr-1"></i>
+            <span>Obtenir les droits de rédaction...</span>
+          </button>
+        </div>
       </div>
-      <div class="text-right">
-        <button v-if="questionnaire.editor"
-          type="submit"
-          class="btn btn-gray"
-          title="Obtenir les droits de rédaction..."
-          data-toggle="modal"
-          data-target="#requestEditorModal">
-          <i class="fa fa-exchange-alt mr-1"></i>
-          <span>Obtenir les droits de rédaction...</span>
-        </button>
-        <button v-else
-          type="submit"
-          class="btn btn-gray"
-          title="Obtenir les droits de rédaction..."
-          @click="switchToEditorPage"
-          >
-          <i class="fa fa-exchange-alt mr-1"></i>
-          <span>Obtenir les droits de rédaction...</span>
-        </button>
-      </div>
+      <error-bar class="mt-4">
+        bli
+      </error-bar>
     </div>
     <request-editor-modal id="requestEditorModal" :questionnaire='questionnaire'></request-editor-modal>
     <become-editor-modal id="becomeEditorModal" :questionnaire-id='questionnaire.id'></become-editor-modal>
@@ -40,6 +45,7 @@
 <script>
 import backendUrls from '../utils/backend.js'
 import BecomeEditorModal from '../editors/BecomeEditorModal'
+import ErrorBar from '../utils/ErrorBar'
 import { mapFields } from 'vuex-map-fields'
 import RequestEditorModal from '../editors/RequestEditorModal'
 import Vue from 'vue'
@@ -47,8 +53,9 @@ import Vue from 'vue'
 export default Vue.extend({
   props: ['questionnaire'],
   components: {
-    RequestEditorModal,
     BecomeEditorModal,
+    ErrorBar,
+    RequestEditorModal,
   },
   computed: {
     ...mapFields(['sessionUser']),

--- a/static/src/questionnaires/QuestionnaireList.vue
+++ b/static/src/questionnaires/QuestionnaireList.vue
@@ -78,52 +78,26 @@
                 </a>
               </template>
               <template v-else>
-                <template v-if="questionnaire.is_draft">
-                  <template v-if="!questionnaire.editor">
-                    <div class="flex-row justify-content-end">
-                      <a :href="'/questionnaire/modifier/' + questionnaire.id "
-                        class="btn btn-primary"
-                        title="Modifier le brouillon de questionnaire"
-                        @click="becomeEditor(questionnaire.id)"
-                      >
-                        <i class="fe fe-edit"></i>
-                        Modifier
-                      </a>
-                      <a :href="questionnaire.url"
-                        class="btn btn-primary ml-2"
-                        title="Voir le brouillon de questionnaire"
-                      >
-                        <i class="fe fe-eye"></i>
-                        Consulter
-                      </a>
-                    <div>
-                  </template>
-                  <a v-else-if="user.id === questionnaire.editor.id"
-                     :href="'/questionnaire/modifier/' + questionnaire.id "
-                     class="btn btn-primary"
-                     title="Modifier le brouillon de questionnaire"
+                <template v-if="questionnaire.is_draft && !!questionnaire.editor && questionnaire.editor.id === user.id">
+                  <a :href="'/questionnaire/modifier/' + questionnaire.id "
+                    class="btn btn-primary"
+                    title="Modifier le brouillon de questionnaire"
+                    @click="becomeEditor(questionnaire.id)"
                   >
                     <i class="fe fe-edit"></i>
                     Modifier
                   </a>
-                  <a v-else-if="user.id !== questionnaire.editor"
-                     :href="questionnaire.url"
-                     class="btn btn-primary"
-                     title="Voir le brouillon de questionnaire"
-                  >
-                    <i class="fe fe-eye"></i>
-                    Consulter
-                  </a>
                 </template>
                 <template v-else>
                   <a :href="questionnaire.url"
-                     class="btn btn-primary"
-                     title="Voir le questionnaire"
+                    class="btn btn-primary ml-2"
+                    title="Voir le brouillon de questionnaire"
                   >
                     <i class="fe fe-eye"></i>
                     Consulter
                   </a>
                 </template>
+              </template>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
When there is no editor for a questionnaire : 
 - In the list of questionnaires, only display one button : Consulter
 - when obtaining right, the flow is simplified : no modals, the user is directed to the questionnaire-edit page.

(Tip : lots of whitespace changes in this PR, use no-whitespace feature for reviewing)