### PR TITLE
Changement Rédacteur - Correctif questionnaire ID vide - alternative

### DIFF
--- a/static/src/editors/SwapEditorButton.vue
+++ b/static/src/editors/SwapEditorButton.vue
@@ -33,16 +33,24 @@ import SwapEditorSuccessModal from '../editors/SwapEditorSuccessModal'
 export default Vue.extend({
   props: [
     'controlId',
-    'questionnaireId',
   ],
+  data: function() {
+    return {
+      questionnaireId: undefined,
+    }
+  },
   components: {
     SwapEditorModal,
     SwapEditorSuccessModal,
   },
   mounted: function() {
-    this.$parent.$on('show-swap-editor-modal', function(data) {
+    const showModal = (questionnaireId) => {
+      console.debug('got questionnaire id', questionnaireId)
+      this.questionnaireId = questionnaireId
       $('#swapEditorModal').modal('show')
-    })
+    }
+
+    this.$parent.$on('show-swap-editor-modal', showModal.bind(this))
   },
   methods: {
     saveDraft: function() {

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <swap-editor-button :control-id="controlId"
-                        :questionnaire-id="questionnaireId"
                         @save-draft="saveDraftBeforeEditorSwap">
     </swap-editor-button>
 
@@ -319,17 +318,20 @@ export default Vue.extend({
       }
       updateQuestionnaire()
       this.saveDraft()
-      this.$emit('show-swap-editor-modal')
+        .then(savedQuestionnaire => {
+          this.$emit('show-swap-editor-modal', savedQuestionnaire.id)
+        })
     },
     saveDraft() {
       this.questionnaire.is_draft = true
-      this._doSave()
+      return this._doSave()
         .then((response) => {
           this._updateQuestionnaire(response.data)
           this.emitQuestionnaireUpdated()
 
           const timeString = moment(new Date()).format('HH:mm:ss')
           this.message = 'Votre dernière sauvegarde a eu lieu à ' + timeString + '.'
+          return response.data
         })
         .catch((error) => {
           console.error(error)


### PR DESCRIPTION
SwapEditorButton doit deja attendre l'event qui vient de QuestionnaireCreate.
Ici, on rajoute un delai à l'envoi de l'event : on attend que le save du questionnaire soit fait. Comme ca le save peut produire le questionnaireId.
