### PR TITLE
Return to questionnaire after editor change

### DIFF
--- a/static/src/editors/BecomeEditorModal.vue
+++ b/static/src/editors/BecomeEditorModal.vue
@@ -72,7 +72,7 @@ import Vue from 'vue'
 Vue.use(Vuex)
 
 export default Vue.extend({
-  props: ['questionnaireId', 'controlId'],
+  props: ['questionnaireId'],
   components: {
     EmptyModal,
   },
@@ -89,11 +89,11 @@ export default Vue.extend({
     becomeEditor() {
       this.callSwapEditorApi(this.sessionUser.id, this.questionnaireId)
         .then((response) => {
-          this.goHome()
+          this.goToWriteablePage()
         })
     },
-    goHome() {
-      const url = backendUrls['control-detail'](this.controlId)
+    goToWriteablePage() {
+      const url = backendUrls['questionnaire-edit'](this.questionnaireId)
       window.location.assign(url)
     },
   },

--- a/static/src/editors/RequestEditorButton.vue
+++ b/static/src/editors/RequestEditorButton.vue
@@ -39,8 +39,7 @@
     </div>
     <request-editor-modal id="requestEditorModal" :questionnaire="questionnaire"></request-editor-modal>
     <become-editor-modal id="becomeEditorModal"
-                         :questionnaire-id="questionnaire.id"
-                         :control-id="questionnaire.control">
+                         :questionnaire-id="questionnaire.id">
     </become-editor-modal>
   </div>
 </template>

--- a/static/src/editors/SwapEditorButton.vue
+++ b/static/src/editors/SwapEditorButton.vue
@@ -21,7 +21,7 @@
                        :questionnaire-id="questionnaireId">
     </swap-editor-modal>
     <swap-editor-success-modal id="swapEditorSuccessModal"
-                               :control-id="controlId"></swap-editor-success-modal>
+                               :questionnaire-id="questionnaireId"></swap-editor-success-modal>
   </div>
 </template>
 

--- a/static/src/editors/SwapEditorSuccessModal.vue
+++ b/static/src/editors/SwapEditorSuccessModal.vue
@@ -15,8 +15,8 @@
       </p>
     </div>
     <div class="modal-footer border-top-0 d-flex justify-content-center">
-      <button @click="goHome()" role="button" class="btn btn-primary">
-        < Revenir à l'accueil
+      <button @click="goToReadonlyPage()" role="button" class="btn btn-primary">
+        OK
       </button>
     </div>
   </empty-modal>
@@ -28,10 +28,10 @@ import EmptyModal from '../utils/EmptyModal'
 import backendUrls from '../utils/backend.js'
 
 export default Vue.extend({
-  props: ['controlId'],
+  props: ['questionnaireId'],
   methods: {
-    goHome() {
-      const url = backendUrls['control-detail'](this.controlId)
+    goToReadonlyPage() {
+      const url = backendUrls['questionnaire-detail'](this.questionnaireId)
       window.location.assign(url)
     },
   },


### PR DESCRIPTION
Fix for #402 
When you take editor rights, you are redirected to the questionnaire-edit page (instead of home).
When you leave editor rights, you are redirected to the questionnaire-detail page (instead of home).
