### PR TITLE
Fix bugs in sidebar

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
         "comma-dangle": ["error", "always-multiline"],
         "no-useless-return": "off",
         "space-before-function-paren": "off",
-        "jest/expect-expect": "off"
+        "jest/expect-expect": "off",
+        "max-len": ["error", { "code": 100 }]
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.rulers": [
-    120
+    100
   ],
   "files.trimTrailingWhitespace": true,
   "editor.tabSize": 2,

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
       "^.+\\.js$": "<rootDir>/node_modules/babel-jest",
       ".*\\.(vue)$": "<rootDir>/node_modules/vue-jest"
     },
+    "moduleNameMapper": {
+      "^.+\\.(css|less)$": "<rootDir>/static/css/test/CSSStub.js"
+    },
     "snapshotSerializers": [
       "<rootDir>/node_modules/jest-serializer-vue"
     ]

--- a/static/css/test/CSSStub.js
+++ b/static/css/test/CSSStub.js
@@ -1,0 +1,2 @@
+// CSS stub file (empty on purpose) so that Jest tests son't break on css imports.
+module.exports = {}

--- a/static/src/sidebar.js
+++ b/static/src/sidebar.js
@@ -16,5 +16,6 @@ new Vue({ // eslint-disable-line no-new
   },
   mounted() {
     this.$store.dispatch('fetchSessionUser')
+    this.$store.dispatch('fetchControls')
   },
 })

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -88,6 +88,14 @@ export default Vue.extend({
     ErrorBar,
     SidebarMenu,
   },
+  props: {
+    // Pass window object as prop, so that we can pass a mock for testing.
+    // Do not use "window" or "document" directly in this file, instead use "this.window" and
+    // "this.window.document"
+    window: {
+      default: () => window,
+    },
+  },
   data() {
     return {
       collapsed: false,
@@ -136,11 +144,11 @@ export default Vue.extend({
     },
   },
   mounted: function() {
-    if (window.location.pathname === backend.welcome()) {
+    if (this.window.location.pathname === backend.welcome()) {
       this.showSidebar = false
       // Hack to reduce width of sidebar, until we figure out the layout for collapsed menu (if we
       // ever do).
-      const sidebar = document.getElementsByClassName('sidebar')[0]
+      const sidebar = this.window.document.getElementsByClassName('sidebar')[0]
       sidebar.setAttribute('style', 'width: 135px;')
       return
     }
@@ -175,10 +183,10 @@ export default Vue.extend({
       // If we are on a create-questionnaire page, find the control for which the questionnaire is
       // being created.
       const controlCreatingQuestionnaire =
-          backend.getIdFromViewUrl(window.location.pathname, 'questionnaire-create')
+          backend.getIdFromViewUrl(this.window.location.pathname, 'questionnaire-create')
 
       // If we are on a trash page, find the control for which the trash folder is.
-      const questionnaireForTrash = backend.getIdFromViewUrl(window.location.pathname, 'trash')
+      const questionnaireForTrash = backend.getIdFromViewUrl(this.window.location.pathname, 'trash')
 
       const menu = this.controls.sort((a, b) => { return b.id - a.id })
         .map(control => {

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -6,63 +6,63 @@
       </a>
     </div>
 
-    <div class="card-header flex-row justify-content-center border-top">
-      <div class="card-title">
-        Mes espaces de dépôt
-      </div>
-    </div>
-
-    <div v-if="isLoaded && controls.length === 0">
-      <div class="text-muted card-title text-center mx-7 mt-10 mb-4">
-        <div v-if="user.is_inspector">
-          Vous n'avez pas encore créé d'espace de dépôt.
-        </div>
-        <div v-else>
-          Vous n'avez pas d'espace de dépôt.
+    <div v-if="showSidebar">
+      <div class="card-header flex-row justify-content-center border-top">
+        <div class="card-title">
+          Mes espaces de dépôt
         </div>
       </div>
-    </div>
 
-    <div v-if="user && user.is_inspector"
-         class="card-header flex-row justify-content-center border-0">
-      <control-create></control-create>
-    </div>
-
-    <div v-if="!collapsed && !isLoaded && !hasError"
-         class="sidebar-load-message card-header border-0 mt-4 mb-4">
-      <div class="loader mr-2"></div>
-      En attente de la liste d'espaces...
-    </div>
-
-    <error-bar id="sidebar-error-bar" v-if="hasError" noclose=true>
-      <div>
-        Nous n'avons pas pu obtenir vos espaces de dépôt.
+      <div v-if="isLoaded && controls.length === 0">
+        <div class="text-muted card-title text-center mx-7 mt-10 mb-4">
+          <div v-if="user.is_inspector">
+            Vous n'avez pas encore créé d'espace de dépôt.
+          </div>
+          <div v-else>
+            Vous n'avez pas d'espace de dépôt.
+          </div>
+        </div>
       </div>
-      <div class="mt-2">
-        Erreur : {{ errorMessage }}
-      </div>
-      <div class="mt-2">
-        Vous pouvez essayer de recharger la page, ou
-        <a :href="'mailto:' + errorEmailLink + JSON.stringify(error)"
-           target="_blank"
-        >
-          cliquez ici pour nous contacter
-        </a>.
-      </div>
-    </error-bar>
 
-    <sidebar-menu class="sidebar-body"
-                  :menu="menu"
-                  :relative="true"
-                  :hideToggle="true"
-                  :show-one-child="true"
-                  theme="white-theme"
-                  :collapsed="collapsed"
-                  @toggle-collapse="onToggleCollapse"
-                  @item-click="onItemClick"
-    >
-    </sidebar-menu>
+      <div v-if="user && user.is_inspector"
+          class="card-header flex-row justify-content-center border-0">
+        <control-create></control-create>
+      </div>
 
+      <div v-if="!collapsed && !isLoaded && !hasError"
+          class="sidebar-load-message card-header border-0 mt-4 mb-4">
+        <div class="loader mr-2"></div>
+        En attente de la liste d'espaces...
+      </div>
+
+      <error-bar id="sidebar-error-bar" v-if="hasError" noclose=true>
+        <div>
+          Nous n'avons pas pu obtenir vos espaces de dépôt.
+        </div>
+        <div class="mt-2">
+          Erreur : {{ errorMessage }}
+        </div>
+        <div class="mt-2">
+          Vous pouvez essayer de recharger la page, ou
+          <a :href="'mailto:' + errorEmailLink + JSON.stringify(error)"
+            target="_blank"
+          >
+            cliquez ici pour nous contacter
+          </a>.
+        </div>
+      </error-bar>
+
+      <sidebar-menu class="sidebar-body"
+                    :menu="menu"
+                    :relative="true"
+                    :hideToggle="true"
+                    :show-one-child="true"
+                    theme="white-theme"
+                    :collapsed="collapsed"
+                    @item-click="onItemClick"
+      >
+      </sidebar-menu>
+    </div>
   </div>
 </template>
 
@@ -98,6 +98,7 @@ export default Vue.extend({
           '&body=' + ERROR_EMAIL_BODY,
       isMenuBuilt: false,
       menu: [],
+      showSidebar: true,
     }
   },
   computed: {
@@ -134,12 +135,11 @@ export default Vue.extend({
   },
   mounted: function() {
     if (window.location.pathname === backend.welcome()) {
-      this.collapsed = true
-      this.menu = []
-      this.moveBodyForCollapse()
-      // Hack for top bar to stay on top, until we figure out the layout for collapsed menu.
-      const topBar = document.getElementsByClassName('sidebar-header')[0]
-      topBar.setAttribute('style', 'width: 100%;')
+      this.showSidebar = false
+      // Hack to reduce width of sidebar, until we figure out the layout for collapsed menu (if we
+      // ever do).
+      const sidebar = document.getElementsByClassName('sidebar')[0]
+      sidebar.setAttribute('style', 'width: 135px;')
       return
     }
   },
@@ -219,23 +219,6 @@ export default Vue.extend({
         })
       this.isMenuBuilt = true
       this.menu = menu
-    },
-    moveBodyForCollapse () {
-      const element = document.getElementById('page-main')
-      element.classList.add('sidebar-collapsed')
-    },
-    moveBodyForUncollapse () {
-      const element = document.getElementById('page-main')
-      element.classList.remove('sidebar-collapsed')
-    },
-    onToggleCollapse (collapsed) {
-      console.log(collapsed)
-      this.collapsed = collapsed
-      if (collapsed) {
-        this.moveBodyForCollapse()
-      } else {
-        this.moveBodyForUncollapse()
-      }
     },
     onItemClick (event, item) {
       console.debug('onItemClick', event, item)

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -115,22 +115,24 @@ export default Vue.extend({
   },
   watch: {
     controlsLoadStatus(newValue, oldValue) {
-      if (newValue === loadStatuses.ERROR) {
+      if (this.showSidebar && newValue === loadStatuses.ERROR) {
         this.displayError('Erreur lors du chargement des espaces. Essayez de recharger la page.')
         return
       }
     },
     userLoadStatus(newValue, oldValue) {
-      if (newValue === loadStatuses.ERROR) {
+      if (this.showSidebar && newValue === loadStatuses.ERROR) {
         this.displayError('Erreur lors du chargement des espaces. Essayez de recharger la page.')
         return
       }
     },
     isLoaded(newValue, oldValue) {
-      if (newValue === false) {
-        return
+      if (this.showSidebar) {
+        if (newValue === false) {
+          return
+        }
+        this.buildMenu()
       }
-      this.buildMenu()
     },
   },
   mounted: function() {

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -34,7 +34,7 @@
       En attente de la liste d'espaces...
     </div>
 
-    <error-bar v-if="hasError" noclose=true>
+    <error-bar id="sidebar-error-bar" v-if="hasError" noclose=true>
       <div>
         Nous n'avons pas pu obtenir vos espaces de dépôt.
       </div>
@@ -93,7 +93,7 @@ export default Vue.extend({
       collapsed: false,
       hasError: false,
       error: undefined,
-      errorMessage: '',
+      errorMessage: undefined,
       errorEmailLink: ERROR_EMAIL_TO + '?subject=' + ERROR_EMAIL_SUBJECT +
           '&body=' + ERROR_EMAIL_BODY,
       isMenuBuilt: false,

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -23,11 +23,13 @@
       </div>
     </div>
 
-    <div v-if="user && user.is_inspector" class="card-header flex-row justify-content-center border-0">
+    <div v-if="user && user.is_inspector"
+         class="card-header flex-row justify-content-center border-0">
       <control-create></control-create>
     </div>
 
-    <div v-if="!collapsed && !isLoaded && !hasError" class="sidebar-load-message card-header border-0 mt-4 mb-4">
+    <div v-if="!collapsed && !isLoaded && !hasError"
+         class="sidebar-load-message card-header border-0 mt-4 mb-4">
       <div class="loader mr-2"></div>
       En attente de la liste d'espaces...
     </div>
@@ -41,7 +43,7 @@
       </div>
       <div class="mt-2">
         Vous pouvez essayer de recharger la page, ou
-        <a :href="'mailto:' + errorEmailTo + '?subject=' + errorEmailSubject + '&body=' + errorEmailBody + JSON.stringify(error)"
+        <a :href="'mailto:' + errorEmailLink + JSON.stringify(error)"
            target="_blank"
         >
           cliquez ici pour nous contacter
@@ -74,7 +76,9 @@ import { SidebarMenu } from 'vue-sidebar-menu'
 import Vue from 'vue'
 import 'vue-sidebar-menu/dist/vue-sidebar-menu.css'
 
-const ERROR_EMAIL_BODY = 'Bonjour,%0D%0A%0D%0AJe voudrais vous signaler une erreur lors du chargement des espaces de dépôt dans le menu. Les détails sont ci-dessous.%0D%0A%0D%0ACordialement,%0D%0A%0D%0A%0D%0A-----------%0D%0A'
+const ERROR_EMAIL_BODY = 'Bonjour,%0D%0A%0D%0A' +
+    'Je voudrais vous signaler une erreur lors du chargement des espaces de dépôt dans le menu.' +
+    ' Les détails sont ci-dessous.%0D%0A%0D%0ACordialement,%0D%0A%0D%0A%0D%0A-----------%0D%0A'
 const ERROR_EMAIL_SUBJECT = 'Erreur de chargement des espaces de dépôt'
 const ERROR_EMAIL_TO = 'e-controle@beta.gouv.fr'
 
@@ -90,9 +94,8 @@ export default Vue.extend({
       hasError: false,
       error: undefined,
       errorMessage: '',
-      errorEmailBody: ERROR_EMAIL_BODY,
-      errorEmailSubject: ERROR_EMAIL_SUBJECT,
-      errorEmailTo: ERROR_EMAIL_TO,
+      errorEmailLink: ERROR_EMAIL_TO + '?subject=' + ERROR_EMAIL_SUBJECT +
+          '&body=' + ERROR_EMAIL_BODY,
       isMenuBuilt: false,
       menu: [],
     }
@@ -105,7 +108,8 @@ export default Vue.extend({
       controlsLoadStatus: 'controlsLoadStatus',
     }),
     isLoaded() {
-      return this.controlsLoadStatus === loadStatuses.SUCCESS && this.userLoadStatus === loadStatuses.SUCCESS
+      return this.controlsLoadStatus === loadStatuses.SUCCESS &&
+          this.userLoadStatus === loadStatuses.SUCCESS
     },
   },
   watch: {
@@ -166,8 +170,10 @@ export default Vue.extend({
         return backend['questionnaire-detail'](questionnaire.id)
       }
 
-      // If we are on a create-questionnaire page, find the control for which the questionnaire is being created.
-      const controlCreatingQuestionnaire = backend.getIdFromViewUrl(window.location.pathname, 'questionnaire-create')
+      // If we are on a create-questionnaire page, find the control for which the questionnaire is
+      // being created.
+      const controlCreatingQuestionnaire =
+          backend.getIdFromViewUrl(window.location.pathname, 'questionnaire-create')
 
       // If we are on a trash page, find the control for which the trash folder is.
       const questionnaireForTrash = backend.getIdFromViewUrl(window.location.pathname, 'trash')
@@ -281,7 +287,8 @@ export default Vue.extend({
     color: #495057;
     background-color: white;
   }
-  .v-sidebar-menu.vsm_white-theme .vsm--link_level-1.vsm--link_exact-active .vsm--icon, .v-sidebar-menu.vsm_white-theme .vsm--link_level-1.vsm--link_active .vsm--icon {
+  .v-sidebar-menu.vsm_white-theme .vsm--link_level-1.vsm--link_exact-active .vsm--icon,
+  .v-sidebar-menu.vsm_white-theme .vsm--link_level-1.vsm--link_active .vsm--icon {
     color: #495057;
     background-color: white;
   }

--- a/static/src/utils/test/Sidebar.spec.js
+++ b/static/src/utils/test/Sidebar.spec.js
@@ -23,6 +23,18 @@ describe('Sidebar.vue', () => {
       },
       mutations: {
         updateField,
+        updateControls(state, controls) {
+          state.controls = controls
+        },
+        updateControlsLoadStatus(state, newStatus) {
+          state.controlsLoadStatus = newStatus
+        },
+        updateSessionUser(state, user) {
+          state.sessionUser = user
+        },
+        updateSessionUserLoadStatus(state, newStatus) {
+          state.sessionUserLoadStatus = newStatus
+        },
       },
     })
   })
@@ -35,5 +47,54 @@ describe('Sidebar.vue', () => {
         localVue,
       })
     expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+
+  test('shows menu', () => {
+    const user = { id: 123, is_inspector: true }
+    const controls = [{
+      id: 345,
+      title: 'Controle de Bloup',
+      reference_code: '2020_bloup',
+      depositing_organization: 'Mairie de Bloup',
+      questionnaires: [{
+        id: 678,
+        is_draft: false,
+        numbering: 3,
+        title: 'On veut des réponses',
+      }],
+    }]
+
+    const wrapper = shallowMount(
+      Sidebar,
+      {
+        store,
+        localVue,
+      })
+
+    store.commit('updateSessionUser', user)
+    store.commit('updateSessionUserLoadStatus', loadStatuses.SUCCESS)
+
+    store.commit('updateControls', controls)
+    store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+
+    expect(wrapper.vm.isMenuBuilt).toBeTruthy()
+
+    expect(wrapper.vm.menu).toHaveLength(1)
+    const controlMenuItem = wrapper.vm.menu[0]
+    expect(controlMenuItem.title).toEqual(
+      expect.stringContaining(controls[0].reference_code))
+    expect(controlMenuItem.title).toEqual(
+      expect.stringContaining(controls[0].depositing_organization))
+    expect(controlMenuItem.href).toEqual(expect.stringContaining('' + controls[0].id))
+
+    expect(controlMenuItem.child).toHaveLength(1)
+    const questionnaireMenuItem = controlMenuItem.child[0]
+    const questionnaire = controls[0].questionnaires[0]
+    expect(questionnaireMenuItem.title).toEqual(
+      expect.stringContaining(questionnaire.title))
+    expect(questionnaireMenuItem.title).toEqual(
+      expect.stringContaining('' + questionnaire.numbering))
+    expect(questionnaireMenuItem.href).toEqual(
+      expect.stringContaining('' + questionnaire.id))
   })
 })

--- a/static/src/utils/test/Sidebar.spec.js
+++ b/static/src/utils/test/Sidebar.spec.js
@@ -9,18 +9,26 @@ const localVue = createLocalVue()
 localVue.use(Vuex)
 
 describe('Sidebar.vue', () => {
-  const user = { id: 123, is_inspector: true }
+  const user = { id: 123, is_inspector: true, is_audited: false }
   const controls = [{
     id: 345,
     title: 'Controle de Bloup',
     reference_code: '2020_bloup',
     depositing_organization: 'Mairie de Bloup',
-    questionnaires: [{
-      id: 678,
-      is_draft: false,
-      numbering: 3,
-      title: 'On veut des réponses',
-    }],
+    questionnaires: [
+      {
+        id: 678,
+        is_draft: false,
+        numbering: 3,
+        title: 'On veut des réponses',
+      },
+      {
+        id: 679,
+        is_draft: true,
+        numbering: 5,
+        title: 'Sérieux on veut des réponses',
+      },
+    ],
   }]
 
   let store
@@ -82,9 +90,18 @@ describe('Sidebar.vue', () => {
       expect.stringContaining(controls[0].depositing_organization))
     expect(controlMenuItem.href).toEqual(expect.stringContaining('' + controls[0].id))
 
-    expect(controlMenuItem.child).toHaveLength(1)
-    const questionnaireMenuItem = controlMenuItem.child[0]
-    const questionnaire = controls[0].questionnaires[0]
+    expect(controlMenuItem.child).toHaveLength(2)
+    let questionnaireMenuItem = controlMenuItem.child[0]
+    let questionnaire = controls[0].questionnaires[0]
+    expect(questionnaireMenuItem.title).toEqual(
+      expect.stringContaining(questionnaire.title))
+    expect(questionnaireMenuItem.title).toEqual(
+      expect.stringContaining('' + questionnaire.numbering))
+    expect(questionnaireMenuItem.href).toEqual(
+      expect.stringContaining('' + questionnaire.id))
+
+    questionnaireMenuItem = controlMenuItem.child[1]
+    questionnaire = controls[0].questionnaires[1]
     expect(questionnaireMenuItem.title).toEqual(
       expect.stringContaining(questionnaire.title))
     expect(questionnaireMenuItem.title).toEqual(
@@ -127,6 +144,27 @@ describe('Sidebar.vue', () => {
     expect(wrapper.find('#sidebar-error-bar').isVisible()).toBeTruthy()
     expect(wrapper.find('#sidebar-error-bar').element.innerHTML).toEqual(
       expect.stringContaining(wrapper.vm.errorMessage))
+  })
+
+  test('does not show drafts for audited user', () => {
+    user.is_inspector = false
+    user.is_audited = true
+    expect(controls[0].questionnaires).toHaveLength(2)
+
+    store.commit('updateSessionUser', user)
+    store.commit('updateSessionUserLoadStatus', loadStatuses.SUCCESS)
+
+    store.commit('updateControls', controls)
+    store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+
+    expect(wrapper.vm.isMenuBuilt).toBeTruthy()
+    expect(wrapper.vm.menu).toHaveLength(1)
+
+    const controlMenuItem = wrapper.vm.menu[0]
+    expect(controlMenuItem.child).toHaveLength(1)
+  })
+
+  test('uses appropriate href for questionnaire', () => {
   })
 
   test('does not display on welcome pages', () => {

--- a/static/src/utils/test/Sidebar.spec.js
+++ b/static/src/utils/test/Sidebar.spec.js
@@ -1,0 +1,39 @@
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import { getField, updateField } from 'vuex-map-fields'
+
+import { loadStatuses } from '../../store'
+import Sidebar from '../Sidebar'
+import Vuex from 'vuex'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+
+describe('Sidebar.vue', () => {
+  let store
+  beforeEach(() => {
+    store = new Vuex.Store({
+      state: {
+        controls: [],
+        controlsLoadStatus: loadStatuses.LOADING,
+        sessionUser: {},
+        sessionUserLoadStatus: loadStatuses.LOADING,
+      },
+      getters: {
+        getField,
+      },
+      mutations: {
+        updateField,
+      },
+    })
+  })
+
+  test('is a Vue instance', () => {
+    const wrapper = shallowMount(
+      Sidebar,
+      {
+        store,
+        localVue,
+      })
+    expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+})

--- a/static/src/utils/test/Sidebar.spec.js
+++ b/static/src/utils/test/Sidebar.spec.js
@@ -9,7 +9,22 @@ const localVue = createLocalVue()
 localVue.use(Vuex)
 
 describe('Sidebar.vue', () => {
+  const user = { id: 123, is_inspector: true }
+  const controls = [{
+    id: 345,
+    title: 'Controle de Bloup',
+    reference_code: '2020_bloup',
+    depositing_organization: 'Mairie de Bloup',
+    questionnaires: [{
+      id: 678,
+      is_draft: false,
+      numbering: 3,
+      title: 'On veut des réponses',
+    }],
+  }]
+
   let store
+  let wrapper
   beforeEach(() => {
     store = new Vuex.Store({
       state: {
@@ -37,40 +52,20 @@ describe('Sidebar.vue', () => {
         },
       },
     })
-  })
 
-  test('is a Vue instance', () => {
-    const wrapper = shallowMount(
+    wrapper = shallowMount(
       Sidebar,
       {
         store,
         localVue,
       })
+  })
+
+  test('is a Vue instance', () => {
     expect(wrapper.isVueInstance()).toBeTruthy()
   })
 
   test('shows menu', () => {
-    const user = { id: 123, is_inspector: true }
-    const controls = [{
-      id: 345,
-      title: 'Controle de Bloup',
-      reference_code: '2020_bloup',
-      depositing_organization: 'Mairie de Bloup',
-      questionnaires: [{
-        id: 678,
-        is_draft: false,
-        numbering: 3,
-        title: 'On veut des réponses',
-      }],
-    }]
-
-    const wrapper = shallowMount(
-      Sidebar,
-      {
-        store,
-        localVue,
-      })
-
     store.commit('updateSessionUser', user)
     store.commit('updateSessionUserLoadStatus', loadStatuses.SUCCESS)
 
@@ -96,5 +91,23 @@ describe('Sidebar.vue', () => {
       expect.stringContaining('' + questionnaire.numbering))
     expect(questionnaireMenuItem.href).toEqual(
       expect.stringContaining('' + questionnaire.id))
+  })
+
+  test('shows error if controls are not fetched', () => {
+    store.commit('updateSessionUser', user)
+    store.commit('updateSessionUserLoadStatus', loadStatuses.SUCCESS)
+
+    store.commit('updateControlsLoadStatus', loadStatuses.ERROR)
+
+    expect(wrapper.vm.isMenuBuilt).toBeFalsy()
+    expect(wrapper.vm.menu).toHaveLength(0)
+
+    expect(wrapper.vm.hasError).toBeTruthy()
+    expect(wrapper.vm.errorMessage).not.toBeUndefined()
+
+    // Error message is displayed in error-bar
+    expect(wrapper.find('#sidebar-error-bar').isVisible()).toBeTruthy()
+    expect(wrapper.find('#sidebar-error-bar').element.innerHTML).toEqual(
+      expect.stringContaining(wrapper.vm.errorMessage))
   })
 })

--- a/static/src/utils/test/Sidebar.spec.js
+++ b/static/src/utils/test/Sidebar.spec.js
@@ -110,4 +110,43 @@ describe('Sidebar.vue', () => {
     expect(wrapper.find('#sidebar-error-bar').element.innerHTML).toEqual(
       expect.stringContaining(wrapper.vm.errorMessage))
   })
+
+  test('does not display on welcome pages', () => {
+    // Mock out window.location.pathname
+    global.window = Object.create(window)
+    const path = '/bienvenue/'
+    Object.defineProperty(window, 'location', {
+      value: {
+        pathname: path,
+      },
+    })
+    expect(window.location.pathname).toEqual(path)
+
+    // Mock out document.getElementsByClassName, used to fix sidebar width
+    const spy = jest.spyOn(document, 'getElementsByClassName')
+    document.getElementsByClassName.mockImplementation(() => {
+      return [{
+        setAttribute: () => {},
+      }]
+    })
+
+    const wrapper = shallowMount(
+      Sidebar,
+      {
+        store,
+        localVue,
+      })
+
+    store.commit('updateSessionUser', user)
+    store.commit('updateSessionUserLoadStatus', loadStatuses.SUCCESS)
+
+    store.commit('updateControls', controls)
+    store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+
+    // Width has been fixed
+    expect(spy).toHaveBeenCalled()
+    // Menu is not built, even though the data was succesfully fetched from store.
+    expect(wrapper.vm.isMenuBuilt).toBeFalsy()
+    expect(wrapper.vm.menu).toHaveLength(0)
+  })
 })

--- a/static/src/utils/test/Sidebar.spec.js
+++ b/static/src/utils/test/Sidebar.spec.js
@@ -111,6 +111,24 @@ describe('Sidebar.vue', () => {
       expect.stringContaining(wrapper.vm.errorMessage))
   })
 
+  test('shows error if user is not fetched', () => {
+    store.commit('updateSessionUserLoadStatus', loadStatuses.ERROR)
+
+    store.commit('updateControls', controls)
+    store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+
+    expect(wrapper.vm.isMenuBuilt).toBeFalsy()
+    expect(wrapper.vm.menu).toHaveLength(0)
+
+    expect(wrapper.vm.hasError).toBeTruthy()
+    expect(wrapper.vm.errorMessage).not.toBeUndefined()
+
+    // Error message is displayed in error-bar
+    expect(wrapper.find('#sidebar-error-bar').isVisible()).toBeTruthy()
+    expect(wrapper.find('#sidebar-error-bar').element.innerHTML).toEqual(
+      expect.stringContaining(wrapper.vm.errorMessage))
+  })
+
   test('does not display on welcome pages', () => {
     // Mock out window.location.pathname
     global.window = Object.create(window)


### PR DESCRIPTION
Premier bug :
Il y a 2 trucs qui sont demandés au serveur en meme temps : le sessionUser (l'utilisateur connecté actuellement) et la liste des controles. Selon celui qui arrive en premier, ca crée le bug.

Si les controles arrivent en premier, alors le menu est contruit. Le menu verifie si l'utilisateur est controleur pour pouvoir lui afficher les brouillons. Or comme l'utilisateur n'est pas encore arrivé du serveur, le test "utilisateur est controleur?" repond "non" (parce qu'il n'existe pas encore, donc il n'est pas controleur!), et du coup le menu lui cache les brouillons.

Fix : 
 - maintenant que le store fetch les controles, sidebar recupere les controles du store.
 - ajouter watcher sur les loadStatuses, et ne construire le menu que quand les controles et le user sont arrives.

Deuxieme bug : 
Sur la page "bienvenue" (où on approuve les CGU), il ne faut pas loader la sidebar. Elle etait a moitié loadée. 
Fix : bloquer le load avec une variable "showSidebar".

Et aussi :
 - config eslint pour afficher des erreurs pour les lignes de plus de 100 char de long.
 - config vscode pour afficher une barre verticale a 100 char de long.
 - une petite modif de config jest ("moduleNameMapper") pour que les tests ne plantent pas quand le code importe du css
 - des TESTS!! 
