### PR TITLE
Make RequestEditorConfirmModal.vue not closeable

### DIFF
--- a/static/src/editors/RequestEditorButton.vue
+++ b/static/src/editors/RequestEditorButton.vue
@@ -15,7 +15,7 @@
         <div class="text-right">
           <button v-if="questionnaire.editor"
             type="submit"
-            class="btn btn-gray"
+            class="btn btn-gray obtain-rights-button"
             title="Obtenir les droits de rédaction..."
             data-toggle="modal"
             data-target="#requestEditorModal">
@@ -24,7 +24,7 @@
           </button>
           <button v-else
             type="submit"
-            class="btn btn-gray"
+            class="btn btn-gray obtain-rights-button"
             title="Obtenir les droits de rédaction..."
             @click="takeEditorRights"
             >
@@ -51,6 +51,7 @@
 </template>
 
 <script>
+import axios from 'axios'
 import backendUrls from '../utils/backend.js'
 import RequestEditorConfirmModal from '../editors/RequestEditorConfirmModal'
 import ErrorBar from '../utils/ErrorBar'
@@ -59,7 +60,15 @@ import RequestEditorModal from '../editors/RequestEditorModal'
 import Vue from 'vue'
 
 export default Vue.extend({
-  props: ['questionnaire'],
+  props: {
+    questionnaire: {},
+    // Pass window object as prop, so that we can pass a mock for testing.
+    // Do not use "window" or "document" directly in this file, instead use "this.window" and
+    // "this.window.document"
+    window: {
+      default: () => window,
+    },
+  },
   data: function() {
     return {
       errorMessage: '',
@@ -76,7 +85,7 @@ export default Vue.extend({
   methods: {
     callSwapEditorApi(editorUser, questionnaireId) {
       const url = backendUrls.swapEditor(questionnaireId)
-      return Vue.axios.put(url, {
+      return axios.put(url, {
         editor: editorUser,
       })
     },
@@ -85,7 +94,7 @@ export default Vue.extend({
       this.callSwapEditorApi(this.sessionUser.id, this.questionnaire.id)
         .then((response) => {
           console.debug('got editing rights', response)
-          window.location.assign(backendUrls['questionnaire-edit'](this.questionnaire.id))
+          this.window.location.assign(backendUrls['questionnaire-edit'](this.questionnaire.id))
         })
         .catch(error => {
           console.error(error)

--- a/static/src/editors/RequestEditorConfirmModal.vue
+++ b/static/src/editors/RequestEditorConfirmModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <empty-modal>
+  <empty-modal :no-close="true">
     <div class="modal-body">
       <form @submit.prevent="confirm">
 
@@ -8,11 +8,6 @@
             Vous êtes sur le point de forcer le transfert des droits
             de ce questionnaire, en conséquence :
           </h4>
-          <button type="button"
-                  class="close"
-                  data-dismiss="modal"
-                  aria-label="Close">
-          </button>
         </div>
 
         <div class="modal-body">

--- a/static/src/editors/RequestEditorModal.vue
+++ b/static/src/editors/RequestEditorModal.vue
@@ -42,10 +42,10 @@
                   </div>
                   <button type="submit"
                     class="btn btn-primary"
-                    title="Forcer le transfert des droits"
+                    title="Forcer le transfert des droits..."
                     @click="requestEditor()">
                     <i class="fa fa-exchange-alt mr-1"></i>
-                    Forcer le transfert des droits
+                    Forcer le transfert des droits...
                   </button>
                 </div>
               </div>

--- a/static/src/editors/test/RequestEditorButton.spec.js
+++ b/static/src/editors/test/RequestEditorButton.spec.js
@@ -1,0 +1,89 @@
+import { shallowMount, createLocalVue } from '@vue/test-utils'
+import { getField, updateField } from 'vuex-map-fields'
+import flushPromises from 'flush-promises'
+
+import axios from 'axios'
+import RequestEditorButton from '../RequestEditorButton'
+import Vuex from 'vuex'
+
+const localVue = createLocalVue()
+localVue.use(Vuex)
+jest.mock('axios')
+
+describe('RequestEditorButton.vue', () => {
+  let store
+  const user = { id: 123 }
+  beforeEach(() => {
+    store = new Vuex.Store({
+      state: {
+        sessionUser: user,
+      },
+      getters: {
+        getField,
+      },
+      mutations: {
+        updateField,
+      },
+    })
+  })
+
+  test('is a Vue instance', () => {
+    const questionnaire = {
+      id: 345,
+    }
+    const wrapper = shallowMount(RequestEditorButton,
+      {
+        store,
+        localVue,
+        propsData: {
+          questionnaire: questionnaire,
+        },
+      })
+    expect(wrapper.isVueInstance()).toBeTruthy()
+  })
+
+  describe('if questionnaire has no editor', () => {
+    let wrapper
+    let questionnaire
+    let mockWindow
+    beforeEach(() => {
+      axios.put.mockResolvedValue({})
+      mockWindow = {
+        location: {
+          assign: jest.fn(() => {}),
+        },
+      }
+
+      questionnaire = {
+        id: 345,
+      }
+      wrapper = shallowMount(RequestEditorButton,
+        {
+          store,
+          localVue,
+          propsData: {
+            questionnaire: questionnaire,
+            window: mockWindow,
+          },
+        })
+    })
+
+    test('clicking "Obtain rights" calls the api to take rights', () => {
+      wrapper.find('.obtain-rights-button').trigger('click')
+
+      expect(axios.put).toHaveBeenCalledWith(
+        '/api/questionnaire/' + questionnaire.id + '/changer-redacteur/',
+        { editor: user.id })
+    })
+
+    test('clicking "Obtain rights" redirects to non-editable page', async () => {
+      wrapper.find('.obtain-rights-button').trigger('click')
+
+      await flushPromises()
+
+      expect(mockWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining('modifier'))
+      expect(mockWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining('questionnaire'))
+      expect(mockWindow.location.assign).toHaveBeenCalledWith(expect.stringContaining('' + questionnaire.id))
+    })
+  })
+})

--- a/static/src/utils/EmptyModal.vue
+++ b/static/src/utils/EmptyModal.vue
@@ -10,11 +10,11 @@
 </template>
 
 <script>
-  import Vue from "vue"
+import Vue from 'vue'
 
-  export default Vue.extend({
-    props: ['no-close'],
-  })
+export default Vue.extend({
+  props: ['no-close'],
+})
 
 </script>
 


### PR DESCRIPTION
And throw in a few tests.

We disable closing the modal by clicking anywhere except "Confirm" or "Cancel" buttons. This is to avoid a confusion where users clicked outside the modal, and then weren't sure whether the flow happened or not.