### PR TITLE
Save draft questionnaire before returning home

### DIFF
--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -47,7 +47,7 @@
               class="btn btn-secondary"
               @click="goHome"
       >
-        < Revenir à l'accueil
+        < Revenir à l'espace de dépôt
       </button>
       <div>
         <button v-if="state !== STATES.START"

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -440,9 +440,9 @@ export default Vue.extend({
       $(event.target).addClass('btn-loading')
       this.saveDraft()
         .then(() => {
+          // Whether or not save succeeds, navigate to home
           this.window.location.href = backend['control-detail'](this.currentQuestionnaire.control)
         })
-        // todo what happens if save fails?
     },
   },
 })

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -356,21 +356,20 @@ export default Vue.extend({
       }
       return saveMethod(this.currentQuestionnaire)
     },
+    validateCurrentForm() {
+      if (this.state === STATES.PREVIEW) {
+        return true
+      }
+      if (this.state === STATES.START) {
+        return this.$refs.questionnaireMetadataCreate.validateForm()
+      }
+      if (this.state === STATES.CREATING_BODY) {
+        return this.$refs.questionnaireBodyCreate.validateForm()
+      }
+    },
     saveDraftAndSwapEditor() {
       console.debug('save draft before editor swap')
-      const validateForm = () => {
-        if (this.state === STATES.PREVIEW) {
-          return true
-        }
-        if (this.state === STATES.START) {
-          return this.$refs.questionnaireMetadataCreate.validateForm()
-        }
-        if (this.state === STATES.CREATING_BODY) {
-          return this.$refs.questionnaireBodyCreate.validateForm()
-        }
-      }
-
-      if (!validateForm()) {
+      if (!this.validateCurrentForm()) {
         return
       }
       this.saveDraft()
@@ -427,8 +426,11 @@ export default Vue.extend({
         })
     },
     goHome(event) {
-      // Display a "loading" spinner on clicked button, while the user is redirected, so that they know their click
-      // has been registered.
+      if (!this.validateCurrentForm()) {
+        return
+      }
+      // Display a "loading" spinner on clicked button, while the user is redirected, so that they
+      // know their click has been registered.
       $(event.target).addClass('btn-loading')
 
       window.location.href = backend['control-detail'](this.currentQuestionnaire.control)

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -116,7 +116,9 @@
         </p>
       </div>
       <div class="modal-footer border-top-0 d-flex justify-content-center">
-        <button type="button" class="btn btn-primary"
+        <button id="go-home-button"
+                type="button"
+                class="btn btn-primary"
                 @click="goHome"
         >
           < Revenir à l'accueil
@@ -159,6 +161,10 @@ export default Vue.extend({
     controlHasMultipleInspectors: Boolean,
     questionnaireId: Number,
     questionnaireNumbering: Number,
+    // Pass window dependency for testing
+    window: {
+      default: () => window,
+    },
   },
   data() {
     return {
@@ -432,8 +438,11 @@ export default Vue.extend({
       // Display a "loading" spinner on clicked button, while the user is redirected, so that they
       // know their click has been registered.
       $(event.target).addClass('btn-loading')
-
-      window.location.href = backend['control-detail'](this.currentQuestionnaire.control)
+      this.saveDraft()
+        .then(() => {
+          this.window.location.href = backend['control-detail'](this.currentQuestionnaire.control)
+        })
+        // todo what happens if save fails?
     },
   },
 })

--- a/static/src/questionnaires/test/QuestionnaireCreate.spec.js
+++ b/static/src/questionnaires/test/QuestionnaireCreate.spec.js
@@ -410,7 +410,47 @@ describe('QuestionnaireCreate.vue', () => {
     })
   })
 
+  describe('Navigation', () => {
+    test('Saves draft before returning home', async () => {
+      const controlId = 1
+      const mockWindow = {
+        location: {
+          href: '',
+        },
+      }
+      const wrapper = shallowMount(
+        QuestionnaireCreate,
+        {
+          propsData: {
+            controlId: 1,
+            window: mockWindow,
+          },
+          store,
+          localVue,
+        })
+      store.commit('updateControls', [{ id: controlId }])
+      store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+      // Spy on form validation to make it pass
+      jest.spyOn(wrapper.vm, 'validateCurrentForm')
+      wrapper.vm.validateCurrentForm.mockImplementation(() => true)
+      // Mock axios to return the questionnaire it got in argument
+      axios.post.mockImplementation((url, payload) => {
+        return Promise.resolve({ data: payload })
+      })
+      await flushPromises()
+
+      wrapper.find('#go-home-button').trigger('click')
+      await flushPromises()
+
+      expect(wrapper.vm.validateCurrentForm).toHaveBeenCalled()
+      expect(axios.post).toHaveBeenCalledWith(
+        '/api/questionnaire/',
+        expect.any(Object))
+      expect(mockWindow.location.href).not.toEqual('')
+    })
+
+    // Todo : test the navigation : back, next
+  })
   // Todo : test the swapEditor flow
-  // Todo : test the navigation : back, next
   // Todo : test the save button
 })


### PR DESCRIPTION
Partial fix for #425 

When editing questionnaire, clicking "Return home" will save questionnaire before leaving.

This means if the questionnaire is in an invalid state, the save will be blocked and the user will be prompted to fix the questionnaire, and stay on the page.

If the questionnaire is valid, but the save fails anyway, the user leaves the page anyway. (we could make them stay... I don't know.)
