### PR TITLE
Check new emails for typos

### DIFF
--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -143,13 +143,12 @@ export default Vue.extend({
         first_name: '',
         last_name: '',
         email: '',
+        emailRepeat: '',
         control: '',
         profile_type: '',
       },
-      postResult: [],
       errors: [],
       hasErrors: false,
-      searchResult: {},
       foundUser: false,
       showStep1: true,
       showStep2: false,
@@ -171,22 +170,22 @@ export default Vue.extend({
         first_name: '',
         last_name: '',
         email: '',
+        emailRepeat: '',
         control: '',
         profile_type: '',
       }
+      this.errors = []
+      this.hasErrors = false
+      this.foundUser = false
       this.showStep1 = true
       this.showStep2 = false
-      this.foundUser = false
-      this.hasErrors = false
-      this.errors = []
     },
     addUser() {
       this.formData.control = this.editingControl.id
       this.formData.profile_type = this.editingProfileType
       this.axios.post(backend.user(), this.formData)
         .then(response => {
-          this.postResult = response.data
-          EventBus.$emit('users-changed', this.postResult)
+          EventBus.$emit('users-changed', response.data)
           this.hideThisModal()
         })
         .catch((error) => {
@@ -214,7 +213,6 @@ export default Vue.extend({
         },
       })
         .then(response => {
-          this.searchResult = response.data
           if (response.data.length) {
             this.foundUser = true
             Object.assign(this.formData, response.data[0])

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -103,13 +103,18 @@
           <div class="alert alert-icon alert-primary alert-dismissible" role="alert">
             <i class="fe fe-bell mr-2" aria-hidden="true"></i>
             <button type="button" class="close" data-dismiss="alert"></button>
-            <p>
-              Pensez à informer la personne ajoutée qu'elle pourra désormais se connecter
-              avec son email. Voici le lien à lui envoyer :
-            </p>
-            <p style="word-wrap: break-word;">
-              https://e-controle-beta.ccomptes.fr
-            </p>
+            <div v-if="editingProfileType === 'audited'">
+              <p>
+                Pensez à informer la personne ajoutée qu'elle pourra désormais se connecter
+                avec son email. Voici le lien à lui envoyer :
+              </p>
+              <p style="word-wrap: break-word;">
+                https://e-controle-beta.ccomptes.fr
+              </p>
+            </div>
+            <div v-else>
+              L’équipe recevra un email pour la notifier de l’ajout d’un nouveau membre.
+            </div>
           </div>
           <div class="text-right">
             <button type="button" class="btn btn-secondary" @click="hideThisModal">Annuler</button>

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -22,18 +22,37 @@
             <h4><i class="fa fa-building mr-2"></i><strong>Organisme interrogé</strong></h4>
         </div>
 
-        <form @submit.prevent="findUser" v-if="showStep1" @keydown.esc="resetFormData">
+        <form ref="form1" @submit.prevent="findUser" v-if="showStep1" @keydown.esc="resetFormData">
           <fieldset class="form-fieldset">
             <div class="form-group">
-              <label class="form-label">Email<span class="form-required"></span></label>
+              <label class="form-label">Email<span class="form-required">*</span></label>
               <input type="email"
                      class="form-control"
                      v-bind:class="{ 'state-invalid': errors.email }"
                      v-model="formData.email"
+                     multiple="false"
                      required>
               <p class="text-muted pl-2" v-if="errors.email">
                 <i class="fa fa-warning"></i>
                 {{ errors.email.join(' / ')}}
+              </p>
+            </div>
+            <div class="form-group">
+              <label class="form-label">
+                Confirmez l'email<span class="form-required">*</span>
+              </label>
+              <input :id="'email-repeat-' + editingControl.id"
+                     type="email"
+                     class="form-control"
+                     v-bind:class="{ 'state-invalid': errors.emailRepeat }"
+                     v-model="formData.emailRepeat"
+                     oninput="this.setCustomValidity('')"
+                     autocomplete="off"
+                     multiple="false"
+                     required>
+              <p class="text-muted pl-2" v-if="errors.emailRepeat">
+                <i class="fa fa-warning"></i>
+                {{ errors.emailRepeat.join(' / ')}}
               </p>
             </div>
           </fieldset>
@@ -109,6 +128,7 @@ import VueAxios from 'vue-axios'
 
 import { store } from '../store'
 import EventBus from '../events'
+import reportValidity from 'report-validity'
 
 Vue.use(VueAxios, axios)
 
@@ -174,7 +194,20 @@ export default Vue.extend({
           this.errors = error.response.data
         })
     },
+    validateEmailRepeat() {
+      if (this.formData.email === this.formData.emailRepeat) {
+        return true
+      }
+      const emailRepeatField = document.getElementById('email-repeat-' + this.editingControl.id)
+      emailRepeatField.setCustomValidity('Les deux emails doivent être identiques.')
+      const form1 = this.$refs.form1
+      return reportValidity(form1)
+    },
     findUser() {
+      if (!this.validateEmailRepeat()) {
+        return
+      }
+
       this.axios.get(backend.user(), {
         params: {
           search: this.formData.email,

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -31,6 +31,8 @@
                      v-bind:class="{ 'state-invalid': errors.email }"
                      v-model="formData.email"
                      multiple="false"
+                     :placeholder="editingProfileType === 'inspector' ?
+                       inspectorPlaceHolder : auditedPlaceHolder"
                      required>
               <p class="text-muted pl-2" v-if="errors.email">
                 <i class="fa fa-warning"></i>
@@ -49,6 +51,8 @@
                      oninput="this.setCustomValidity('')"
                      autocomplete="off"
                      multiple="false"
+                     :placeholder="editingProfileType === 'inspector' ?
+                       inspectorPlaceHolder : auditedPlaceHolder"
                      required>
               <p class="text-muted pl-2" v-if="errors.emailRepeat">
                 <i class="fa fa-warning"></i>
@@ -152,6 +156,8 @@ export default Vue.extend({
       foundUser: false,
       showStep1: true,
       showStep2: false,
+      auditedPlaceHolder: 'chloe.henry@abcde.fr',
+      inspectorPlaceHolder: 'julie.ballard@ccomptes.fr',
     }
   },
   computed: {

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -1,6 +1,11 @@
 <template>
 
-<div class="modal fade add-user-modal" id="addUserModal" tabindex="-1" role="dialog" aria-labelledby="addUserModal" aria-hidden="true">
+<div class="modal fade add-user-modal"
+     id="addUserModal"
+     tabindex="-1"
+     role="dialog"
+     aria-labelledby="addUserModal"
+     aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-header">
@@ -21,8 +26,15 @@
           <fieldset class="form-fieldset">
             <div class="form-group">
               <label class="form-label">Email<span class="form-required"></span></label>
-              <input type="email" class="form-control" v-bind:class="{ 'state-invalid': errors.email }" v-model="formData.email" required>
-              <p class="text-muted pl-2" v-if="errors.email"><i class="fa fa-warning"></i> {{ errors.email.join(' / ')}}</p>
+              <input type="email"
+                     class="form-control"
+                     v-bind:class="{ 'state-invalid': errors.email }"
+                     v-model="formData.email"
+                     required>
+              <p class="text-muted pl-2" v-if="errors.email">
+                <i class="fa fa-warning"></i>
+                {{ errors.email.join(' / ')}}
+              </p>
             </div>
           </fieldset>
           <div class="text-right">
@@ -42,13 +54,27 @@
           <fieldset v-else class="form-fieldset">
             <div class="form-group">
               <label class="form-label">Prénom<span class="form-required"></span></label>
-              <input type="text" class="form-control" v-bind:class="{ 'state-invalid': errors.first_name }" v-model="formData.first_name" required>
-              <p class="text-muted pl-2" v-if="errors.first_name"><i class="fa fa-warning"></i> {{ errors.first_name.join(' / ')}}</p>
+              <input type="text"
+                     class="form-control"
+                     v-bind:class="{ 'state-invalid': errors.first_name }"
+                     v-model="formData.first_name"
+                     required>
+              <p class="text-muted pl-2" v-if="errors.first_name">
+                <i class="fa fa-warning"></i>
+                {{ errors.first_name.join(' / ')}}
+              </p>
             </div>
             <div class="form-group">
               <label class="form-label">Nom<span class="form-required"></span></label>
-              <input type="text" class="form-control" v-bind:class="{ 'state-invalid': errors.last_name }" v-model="formData.last_name" required>
-              <p class="text-muted pl-2" v-if="errors.last_name"><i class="fa fa-warning"></i> {{ errors.last_name.join(' / ')}}</p>
+              <input type="text"
+                     class="form-control"
+                     v-bind:class="{ 'state-invalid': errors.last_name }"
+                     v-model="formData.last_name"
+                     required>
+              <p class="text-muted pl-2" v-if="errors.last_name">
+                <i class="fa fa-warning"></i>
+                {{ errors.last_name.join(' / ')}}
+              </p>
             </div>
           </fieldset>
           <div class="alert alert-icon alert-primary alert-dismissible" role="alert">


### PR DESCRIPTION
When adding a new user, enter the email twice to be sure there are no typos.

Also : 
 - add placeholders in the email fields
 - display a different info message when adding an inspector

![Screenshot 2020-02-10 at 18 11 31](https://user-images.githubusercontent.com/911434/74172494-9fb80580-4c30-11ea-8721-233fe974c1fb.png)

![Screenshot 2020-02-10 at 18 12 12](https://user-images.githubusercontent.com/911434/74172528-b3636c00-4c30-11ea-925f-2f0e6e108abf.png)
