### PR TITLE
IE Bugfix : when there are no controls, footer is too high

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -26,6 +26,10 @@
     .ie-flex-column-fix {
         display: block;
     }
+
+    .ie-margin-for-footer {
+        margin-bottom: 30em !important;
+    }
 }
 
 /* Non-IE styles here. Should work for Edge. */

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -98,6 +98,7 @@
     min-height: 100vh;
 }
 #non-footer {
+    min-height: 100vh;
     padding-bottom: 140px; /* Footer height */
 }
 #footer {

--- a/static/src/controls/ControlPage.vue
+++ b/static/src/controls/ControlPage.vue
@@ -7,16 +7,15 @@
         </no-controls>
         <div v-else class="card">
           <div class="card-body">
-            Vous n'avez accès à aucun espace de dépôt. Si vous avez besoin d'un accès, contactez l'équipe de contrôle.
+            Vous n'avez accès à aucun espace de dépôt. Si vous avez besoin d'un accès, contactez
+            l'équipe de contrôle.
           </div>
         </div>
       </div>
 
       <template v-else>
-        <control-card v-for="control in controls"
-                      v-if="hash === '#control-' + control.id "
-                      :key="control.id"
-                      :control="control"
+        <control-card v-if="displayedControl !== undefined"
+                      :control="displayedControl"
                       :user="user"
                       :webdavurl="webdavurl"
         >
@@ -49,72 +48,77 @@
 </template>
 
 <script>
-  import Vue from 'vue'
+import Vue from 'vue'
 
-  import AddUserModal from "../users/AddUserModal"
-  import ControlCard from './ControlCard'
-  import ControlCreate from './ControlCreate'
-  import NoControls from './NoControls'
-  import RemoveUserModal from "../users/RemoveUserModal"
-  import UpdateUserModal from "../users/UpdateUserModal"
-  import VideoModal from "../utils/VideoModal"
+import AddUserModal from '../users/AddUserModal'
+import ControlCard from './ControlCard'
+import NoControls from './NoControls'
+import RemoveUserModal from '../users/RemoveUserModal'
+import UpdateUserModal from '../users/UpdateUserModal'
+import VideoModal from '../utils/VideoModal'
 
-  export default Vue.extend({
-    props: [
-      'controls',
-      'user',
-      'staticFilesUrl',
-      'webdavurl',
-    ],
-    data: function() {
-      return {
-        hash: "",
-      }
+export default Vue.extend({
+  props: [
+    'controls',
+    'user',
+    'staticFilesUrl',
+    'webdavurl',
+  ],
+  data: function() {
+    return {
+      hash: '',
+    }
+  },
+  computed: {
+    displayedControl() {
+      return this.controls.find(control => {
+        return this.hash === '#control-' + control.id
+      })
     },
-    mounted() {
-      const isValidHash = (hash) => {
-        const reg = /^#control-[0-9]+$/
-        return reg.test(hash)
+  },
+  mounted() {
+    const isValidHash = (hash) => {
+      const reg = /^#control-[0-9]+$/
+      return reg.test(hash)
+    }
+
+    const hashPointsToExistingControl = (hash) => {
+      if (!isValidHash(hash)) {
+        return false
       }
-
-      const hashPointsToExistingControl = (hash) => {
-        if (!isValidHash(hash)) {
-          return false
-        }
-        const controlId = parseInt(hash.replace('#control-', ''), 10)
-        if (isNaN(controlId)) {
-          return false
-        }
-        return this.controls.map(control => control.id).includes(controlId)
+      const controlId = parseInt(hash.replace('#control-', ''), 10)
+      if (isNaN(controlId)) {
+        return false
       }
+      return this.controls.map(control => control.id).includes(controlId)
+    }
 
-      const updateHash = () => {
-        console.debug('hashchange', window.location.hash)
-        if (!hashPointsToExistingControl(window.location.hash) && this.controls.length > 0) {
-          // Change the hash to select the first control in the list, which will trigger the hashchange event again.
-          window.location.hash = '#control-' + this.controls[0].id
-          return
-        }
-        this.hash = window.location.hash
+    const updateHash = () => {
+      console.debug('hashchange', window.location.hash)
+      if (!hashPointsToExistingControl(window.location.hash) && this.controls.length > 0) {
+        // Change the hash to select the first control in the list, which will trigger the
+        // hashchange event again.
+        window.location.hash = '#control-' + this.controls[0].id
+        return
       }
+      this.hash = window.location.hash
+    }
 
-      window.addEventListener(
-          'hashchange',
-          updateHash,
-          false)
+    window.addEventListener(
+      'hashchange',
+      updateHash,
+      false)
 
-      updateHash()
+    updateHash()
+  },
+  components: {
+    AddUserModal,
+    ControlCard,
+    NoControls,
+    RemoveUserModal,
+    UpdateUserModal,
+    VideoModal,
+  },
 
-    },
-    components: {
-      AddUserModal,
-      ControlCard,
-      ControlCreate,
-      NoControls,
-      RemoveUserModal,
-      UpdateUserModal,
-      VideoModal,
-    },
-
-  })
+})
 </script>

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -29,6 +29,11 @@
         <control-create></control-create>
       </div>
 
+      <div v-if="isLoaded && controls.length === 0"
+           class="ie-margin-for-footer">
+        <!-- empty div. Adds margin-bottom to fix a footer bug for IE. -->
+      </div>
+
       <div v-if="!collapsed && !isLoaded && !hasError"
           class="sidebar-load-message card-header border-0 mt-4 mb-4">
         <div class="loader mr-2"></div>


### PR DESCRIPTION
Fixed by adding artifical vertical margin in the sidebar, to push the footer down at its normal place. Hacky but works.

View with ignore-whitespace, there's some linting.