### PR TITLE
Refresh the order field after deleting a question

### DIFF
--- a/static/src/questionnaires/QuestionnaireBodyCreate.vue
+++ b/static/src/questionnaires/QuestionnaireBodyCreate.vue
@@ -209,6 +209,7 @@ export default Vue.extend({
     },
     deleteQuestion: function(themeIndex, qIndex) {
       this.themes[themeIndex].questions.splice(qIndex, 1)
+      this.$_updateOrderFields(this.themes[themeIndex].questions)
     },
     deleteTheme: function(themeIndex) {
       this.themes.splice(themeIndex, 1)


### PR DESCRIPTION
Bugfix : when deleting a question, update the 'order' field, on which is based the 'numbering' field.
Otherwise the docx export has the 'numbering' wrong.

