### PR TITLE
Add ids (and other things) in admin pages

### DIFF
--- a/control/admin.py
+++ b/control/admin.py
@@ -27,8 +27,13 @@ class AdminHelpers(object):
 
 class ParentLinksMixin(object):
     def link_to_theme(self, obj):
-        link = reverse("admin:control_theme_change", args=[obj.theme.id])
-        return format_html('<a href="{}">{}</a>', link, obj.theme)
+        theme = 'unknown'
+        if hasattr(obj, 'theme'):
+            theme = obj.theme
+        if hasattr(obj, 'question'):
+            theme = obj.question.theme
+        link = reverse("admin:control_theme_change", args=[theme.id])
+        return format_html('<a href="{}">{}</a>', link, theme)
     link_to_theme.short_description = 'Theme'
 
     def link_to_questionnaire(self, obj):
@@ -120,9 +125,9 @@ class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, AdminHelper
 
 
 @admin.register(ResponseFile)
-class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers):
+class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers, ParentLinksMixin):
     list_display = (
-        'id', 'file_name', 'question_display', 'questionnaire_display',
+        'id', 'file_name', 'question_display', 'link_to_theme', 'questionnaire_display',
         'control_display', 'created', 'author', 'is_deleted')
     list_display_links = ('id',)
     date_hierarchy = 'created'
@@ -139,9 +144,9 @@ class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers):
 
 
 @admin.register(QuestionFile)
-class QuestionFileAdmin(admin.ModelAdmin, AdminHelpers):
+class QuestionFileAdmin(admin.ModelAdmin, AdminHelpers, ParentLinksMixin):
     list_display = (
-        'id', 'file', 'question_display', 'questionnaire_display',
+        'id', 'file', 'question_display', 'link_to_theme', 'questionnaire_display',
         'control_display')
     list_display_links = ('id',)
     list_filter = (

--- a/control/admin.py
+++ b/control/admin.py
@@ -69,7 +69,7 @@ class QuestionnaireInline(OrderedTabularInline):
     model = Questionnaire
     fields = (
         'id', 'title', 'description', 'uploaded_file', 'generated_file', 'end_date',
-        'move_up_down_links', 'order')
+        'order', 'move_up_down_links')
     readonly_fields = ('id', 'move_up_down_links',)
     extra = 1
 
@@ -82,8 +82,16 @@ class ControlAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin):
     inlines = (QuestionnaireInline, )
 
 
+class ThemeInline(OrderedTabularInline):
+    model = Theme
+    fields = (
+        'id', 'title', 'order', 'move_up_down_links')
+    readonly_fields = ('id', 'order', 'move_up_down_links')
+    extra = 1
+
+
 @admin.register(Questionnaire)
-class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedModelAdmin, ParentLinksMixin):
+class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMixin):
     save_as = True
     list_display = (
         'id', 'title', 'link_to_control', 'numbering', 'order', 'is_draft', 'editor',
@@ -94,6 +102,7 @@ class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedModelAdmin, ParentL
     list_filter = ('control', 'is_draft')
     raw_id_fields = ('editor',)
     actions = ['megacontrol_admin_action']
+    inlines = (ThemeInline, )
 
 
 class QuestionInline(OrderedTabularInline):

--- a/control/admin.py
+++ b/control/admin.py
@@ -26,15 +26,15 @@ class AdminHelpers(object):
 class QuestionnaireInline(OrderedTabularInline):
     model = Questionnaire
     fields = (
-        'title', 'description', 'uploaded_file', 'generated_file', 'end_date',
+        'id', 'title', 'description', 'uploaded_file', 'generated_file', 'end_date',
         'move_up_down_links', 'order')
-    readonly_fields = ('move_up_down_links',)
+    readonly_fields = ('id', 'move_up_down_links',)
     extra = 1
 
 
 @admin.register(Control)
 class ControlAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin):
-    list_display = ('title', 'depositing_organization', 'reference_code')
+    list_display = ('id', 'title', 'depositing_organization', 'reference_code')
     search_fields = (
         'title', 'reference_code', 'questionnaires__title', 'questionnaires__description')
     inlines = (QuestionnaireInline, )
@@ -56,13 +56,13 @@ class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedModelAdmin):
 
 class QuestionInline(OrderedTabularInline):
     model = Question
-    fields = ('description', 'order', 'move_up_down_links')
-    readonly_fields = ('order', 'move_up_down_links')
+    fields = ('id', 'description', 'order', 'move_up_down_links')
+    readonly_fields = ('id', 'order', 'move_up_down_links')
 
 
 @admin.register(Theme)
 class ThemeAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin):
-    list_display = ('numbering', 'title', 'questionnaire', 'move_up_down_links')
+    list_display = ('id', 'numbering', 'title', 'questionnaire', 'move_up_down_links')
     search_fields = ('title',)
     list_filter = ('questionnaire__control', 'questionnaire',)
     inlines = (QuestionInline,)
@@ -77,7 +77,7 @@ class QuestionFileInline(OrderedTabularInline):
 
 @admin.register(Question)
 class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, AdminHelpers):
-    list_display = ('more_details', 'numbering', 'description', 'theme', 'move_up_down_links')
+    list_display = ('id', 'numbering', 'description', 'theme', 'move_up_down_links')
     raw_id_fields = ('theme',)
     list_filter = ('theme', 'theme__questionnaire', 'theme__questionnaire__control')
     search_fields = ('description',)
@@ -87,9 +87,9 @@ class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, AdminHelper
 @admin.register(ResponseFile)
 class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers):
     list_display = (
-        'more_details', 'id', 'file_name', 'question_display', 'questionnaire_display',
+        'id', 'file_name', 'question_display', 'questionnaire_display',
         'control_display', 'created', 'author', 'is_deleted')
-    list_display_links = ('more_details', 'id')
+    list_display_links = ('id',)
     date_hierarchy = 'created'
     list_filter = (
         'question__theme__questionnaire__control', 'question__theme__questionnaire',
@@ -106,9 +106,9 @@ class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers):
 @admin.register(QuestionFile)
 class QuestionFileAdmin(admin.ModelAdmin, AdminHelpers):
     list_display = (
-        'more_details', 'id', 'file', 'question_display', 'questionnaire_display',
+        'id', 'file', 'question_display', 'questionnaire_display',
         'control_display')
-    list_display_links = ('more_details', 'id')
+    list_display_links = ('id',)
     list_filter = (
         'question__theme__questionnaire__control', 'question__theme__questionnaire',
         'question__theme')

--- a/control/admin.py
+++ b/control/admin.py
@@ -79,7 +79,8 @@ class QuestionFileInline(OrderedTabularInline):
 
 @admin.register(Question)
 class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, AdminHelpers):
-    list_display = ('id', 'numbering', 'description', 'link_to_theme', 'move_up_down_links')
+    list_display = ('id', 'numbering', 'description', 'link_to_theme', 'link_to_questionnaire',
+        'link_to_control', 'move_up_down_links')
     raw_id_fields = ('theme',)
     list_filter = ('theme', 'theme__questionnaire', 'theme__questionnaire__control')
     search_fields = ('description',)
@@ -89,6 +90,17 @@ class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, AdminHelper
         link = reverse("admin:control_theme_change", args=[obj.theme.id])
         return format_html('<a href="{}">{}</a>', link, obj.theme)
     link_to_theme.short_description = 'Theme'
+
+    def link_to_questionnaire(self, obj):
+        link = reverse("admin:control_questionnaire_change", args=[obj.theme.questionnaire.id])
+        return format_html('<a href="{}">{}</a>', link, obj.theme.questionnaire)
+    link_to_questionnaire.short_description = 'Questionnaire'
+
+    def link_to_control(self, obj):
+        link = reverse("admin:control_control_change", args=[obj.theme.questionnaire.control.id])
+        return format_html('<a href="{}">{}</a>', link, obj.theme.questionnaire.control)
+    link_to_control.short_description = 'Control'
+
 
 @admin.register(ResponseFile)
 class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers):

--- a/control/admin.py
+++ b/control/admin.py
@@ -5,7 +5,6 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.urls import reverse
 from django.utils.decorators import method_decorator
-from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.views.generic import DetailView, RedirectView
 from django.views.generic.detail import SingleObjectMixin
@@ -32,8 +31,8 @@ class ParentLinksMixin(object):
             theme = obj.theme
         if hasattr(obj, 'question'):
             theme = obj.question.theme
-        link = reverse("admin:control_theme_change", args=[theme.id])
-        return format_html('<a href="{}">{}</a>', link, theme)
+        url = reverse("admin:control_theme_change", args=[theme.id])
+        return mark_safe(f'<a href="{url}">{theme}</a>')
     link_to_theme.short_description = 'Theme'
 
     def link_to_questionnaire(self, obj):
@@ -43,8 +42,8 @@ class ParentLinksMixin(object):
         elif hasattr(obj, 'theme'):
             questionnaire = obj.theme.questionnaire
 
-        link = reverse("admin:control_questionnaire_change", args=[questionnaire.id])
-        return format_html('<a href="{}">{}</a>', link, questionnaire)
+        url = reverse("admin:control_questionnaire_change", args=[questionnaire.id])
+        return mark_safe(f'<a href="{url}">{questionnaire}</a>')
     link_to_questionnaire.short_description = 'Questionnaire'
 
     def link_to_control(self, obj):
@@ -56,8 +55,8 @@ class ParentLinksMixin(object):
         elif hasattr(obj, 'theme'):
             control = obj.theme.questionnaire.control
 
-        link = reverse("admin:control_control_change", args=[control.id])
-        return format_html('<a href="{}">{}</a>', link, control)
+        url = reverse("admin:control_control_change", args=[control.id])
+        return mark_safe(f'<a href="{url}">{control}</a>')
     link_to_control.short_description = 'Control'
 
 

--- a/control/admin.py
+++ b/control/admin.py
@@ -78,6 +78,9 @@ class QuestionnaireInline(OrderedTabularInline):
 class UserProfileInline(admin.TabularInline):
     model = UserProfile.controls.through
     verbose_name_plural = 'Profils Utilisateurs'
+    extra = 1
+    fields = ('userprofile',)
+    raw_id_fields = ('userprofile',)
 
 
 @admin.register(Control)

--- a/control/admin.py
+++ b/control/admin.py
@@ -107,7 +107,7 @@ class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedInlineModelAdminMix
         'sent_date', 'end_date')
     search_fields = ('title', 'description')
     list_filter = ('control', 'is_draft')
-    raw_id_fields = ('editor',)
+    raw_id_fields = ('editor', 'control')
     actions = ['megacontrol_admin_action']
     inlines = (ThemeInline, )
 

--- a/control/admin.py
+++ b/control/admin.py
@@ -74,10 +74,10 @@ class ControlAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin):
 
 
 @admin.register(Questionnaire)
-class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedModelAdmin):
+class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedModelAdmin, ParentLinksMixin):
     save_as = True
     list_display = (
-        'id', 'title', 'control', 'numbering', 'order', 'is_draft', 'editor',
+        'id', 'title', 'link_to_control', 'numbering', 'order', 'is_draft', 'editor',
         'sent_date', 'end_date')
     list_editable = ('order',)
     readonly_fields = ('order',)

--- a/control/admin.py
+++ b/control/admin.py
@@ -94,10 +94,8 @@ class ThemeInline(OrderedTabularInline):
 class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMixin):
     save_as = True
     list_display = (
-        'id', 'title', 'link_to_control', 'numbering', 'order', 'is_draft', 'editor',
+        'id', 'title', 'link_to_control', 'numbering', 'is_draft', 'editor',
         'sent_date', 'end_date')
-    list_editable = ('order',)
-    readonly_fields = ('order',)
     search_fields = ('title', 'description')
     list_filter = ('control', 'is_draft')
     raw_id_fields = ('editor',)
@@ -113,8 +111,7 @@ class QuestionInline(OrderedTabularInline):
 
 @admin.register(Theme)
 class ThemeAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMixin):
-    list_display = ('id', 'numbering', 'title', 'link_to_questionnaire', 'link_to_control',
-        'move_up_down_links')
+    list_display = ('id', 'numbering', 'title', 'link_to_questionnaire', 'link_to_control')
     search_fields = ('title',)
     list_filter = ('questionnaire__control', 'questionnaire',)
     fields = (
@@ -133,7 +130,7 @@ class QuestionFileInline(OrderedTabularInline):
 @admin.register(Question)
 class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMixin):
     list_display = ('id', 'numbering', 'description', 'link_to_theme', 'link_to_questionnaire',
-        'link_to_control', 'move_up_down_links')
+        'link_to_control')
     fields = (
         'id', 'description', 'theme', 'link_to_questionnaire', 'link_to_control')
     readonly_fields = ('id', 'link_to_questionnaire', 'link_to_control')

--- a/control/admin.py
+++ b/control/admin.py
@@ -108,6 +108,9 @@ class ThemeAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMix
         'move_up_down_links')
     search_fields = ('title',)
     list_filter = ('questionnaire__control', 'questionnaire',)
+    fields = (
+        'id', 'title', 'questionnaire', 'link_to_control')
+    readonly_fields = ('id', 'link_to_control')
     inlines = (QuestionInline,)
 
 
@@ -122,6 +125,9 @@ class QuestionFileInline(OrderedTabularInline):
 class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMixin):
     list_display = ('id', 'numbering', 'description', 'link_to_theme', 'link_to_questionnaire',
         'link_to_control', 'move_up_down_links')
+    fields = (
+        'id', 'description', 'theme', 'link_to_questionnaire', 'link_to_control')
+    readonly_fields = ('id', 'link_to_questionnaire', 'link_to_control')
     raw_id_fields = ('theme',)
     list_filter = ('theme', 'theme__questionnaire', 'theme__questionnaire__control')
     search_fields = ('description',)
@@ -141,7 +147,7 @@ class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, ParentLinksMixin):
     fields = (
         'id', 'author', 'file_name', 'link_to_question', 'link_to_questionnaire', 'link_to_control',
         'created', 'modified', 'is_deleted')
-    readonly_fields = ('file_name', 'link_to_questionnaire', 'link_to_control')
+    readonly_fields = ('file_name', 'link_to_question', 'link_to_questionnaire', 'link_to_control')
     search_fields = (
         'file', 'question__description', 'author__first_name', 'author__last_name',
         'author__username')
@@ -157,9 +163,9 @@ class QuestionFileAdmin(admin.ModelAdmin, ParentLinksMixin):
         'question__theme__questionnaire__control', 'question__theme__questionnaire',
         'question__theme')
     fields = (
-        'id', 'file', 'question', 'order')
+        'id', 'file', 'question', 'order', 'link_to_questionnaire', 'link_to_control')
     readonly_fields = (
-        'id', 'order')
+        'id', 'order', 'link_to_questionnaire', 'link_to_control')
     search_fields = ('file', 'question__description')
     raw_id_fields = ('question',)
 

--- a/control/admin.py
+++ b/control/admin.py
@@ -94,7 +94,7 @@ class ThemeInline(OrderedTabularInline):
 class QuestionnaireAdmin(QuestionnaireDuplicateMixin, OrderedInlineModelAdminMixin, OrderedModelAdmin, ParentLinksMixin):
     save_as = True
     list_display = (
-        'id', 'title', 'link_to_control', 'numbering', 'is_draft', 'editor',
+        'id', 'numbering', 'title', 'link_to_control', 'is_draft', 'editor',
         'sent_date', 'end_date')
     search_fields = ('title', 'description')
     list_filter = ('control', 'is_draft')

--- a/control/admin.py
+++ b/control/admin.py
@@ -15,6 +15,7 @@ from ordered_model.admin import OrderedTabularInline, OrderedInlineModelAdminMix
 
 from .models import Control, Questionnaire, Theme, Question, QuestionFile, ResponseFile
 from .questionnaire_duplicate import QuestionnaireDuplicateMixin
+from user_profiles.models import UserProfile
 
 
 class ParentLinksMixin(object):
@@ -74,12 +75,17 @@ class QuestionnaireInline(OrderedTabularInline):
     extra = 1
 
 
+class UserProfileInline(admin.TabularInline):
+    model = UserProfile.controls.through
+    verbose_name_plural = 'Profils Utilisateurs'
+
+
 @admin.register(Control)
 class ControlAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin):
     list_display = ('id', 'title', 'depositing_organization', 'reference_code')
     search_fields = (
         'title', 'reference_code', 'questionnaires__title', 'questionnaires__description')
-    inlines = (QuestionnaireInline, )
+    inlines = (QuestionnaireInline, UserProfileInline, )
 
 
 class ThemeInline(OrderedTabularInline):

--- a/control/admin.py
+++ b/control/admin.py
@@ -3,7 +3,9 @@ from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.urls import reverse
 from django.utils.decorators import method_decorator
+from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 from django.views.generic import DetailView, RedirectView
 from django.views.generic.detail import SingleObjectMixin
@@ -77,12 +79,16 @@ class QuestionFileInline(OrderedTabularInline):
 
 @admin.register(Question)
 class QuestionAdmin(OrderedInlineModelAdminMixin, OrderedModelAdmin, AdminHelpers):
-    list_display = ('id', 'numbering', 'description', 'theme', 'move_up_down_links')
+    list_display = ('id', 'numbering', 'description', 'link_to_theme', 'move_up_down_links')
     raw_id_fields = ('theme',)
     list_filter = ('theme', 'theme__questionnaire', 'theme__questionnaire__control')
     search_fields = ('description',)
     inlines = (QuestionFileInline,)
 
+    def link_to_theme(self, obj):
+        link = reverse("admin:control_theme_change", args=[obj.theme.id])
+        return format_html('<a href="{}">{}</a>', link, obj.theme)
+    link_to_theme.short_description = 'Theme'
 
 @admin.register(ResponseFile)
 class ResponseFileAdmin(ReadOnlyModelAdmin, admin.ModelAdmin, AdminHelpers):

--- a/control/models.py
+++ b/control/models.py
@@ -28,7 +28,7 @@ class WithNumberingMixin(object):
     numbering.fget.short_description = 'Numérotation'
 
 
-class QuestionnaireFileMixin(object):
+class FileInfoMixin(object):
     """
     Add common helpers for file information.
     """
@@ -245,7 +245,7 @@ class Question(OrderedModel, WithNumberingMixin, DocxMixin):
         return f'id {self.id} - {self.description}'
 
 
-class QuestionFile(OrderedModel, QuestionnaireFileMixin):
+class QuestionFile(OrderedModel, FileInfoMixin):
     question = models.ForeignKey(
         to='Question', verbose_name='question', related_name='question_files',
         on_delete=models.CASCADE)
@@ -270,7 +270,7 @@ class QuestionFile(OrderedModel, QuestionnaireFileMixin):
 
 
 @cleanup.ignore
-class ResponseFile(TimeStampedModel, QuestionnaireFileMixin):
+class ResponseFile(TimeStampedModel, FileInfoMixin):
     question = models.ForeignKey(
         to='Question', verbose_name='question', related_name='response_files',
         on_delete=models.CASCADE)

--- a/control/models.py
+++ b/control/models.py
@@ -69,7 +69,7 @@ class QuestionnaireFileMixin(object):
     control_display.fget.short_description = 'control'
 
     def __str__(self):
-        return self.file_name
+        return f'id {self.id} - {self.file_name}'
 
 
 class Control(models.Model):
@@ -124,8 +124,8 @@ class Control(models.Model):
 
     def __str__(self):
         if self.depositing_organization:
-            return f'{self.title} - {self.depositing_organization}'
-        return self.title
+            return f'id {self.id} - {self.title} - {self.depositing_organization}'
+        return f'id {self.id} - {self.title}'
 
 
 class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
@@ -206,7 +206,7 @@ class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return self.title_display
+        return f'id {self.id} - {self.title_display}'
 
 
 class Theme(OrderedModel, WithNumberingMixin):
@@ -222,7 +222,7 @@ class Theme(OrderedModel, WithNumberingMixin):
         verbose_name_plural = "Thèmes"
 
     def __str__(self):
-        return self.title
+        return f'id {self.id} - {self.title}'
 
 
 class Question(OrderedModel, WithNumberingMixin, DocxMixin):
@@ -242,7 +242,7 @@ class Question(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return self.description
+        return f'id {self.id} - {self.description}'
 
 
 class QuestionFile(OrderedModel, QuestionnaireFileMixin):

--- a/control/models.py
+++ b/control/models.py
@@ -37,37 +37,6 @@ class FileInfoMixin(object):
     def file_name(self):
         return self.file.name
 
-    @property
-    def question_display(self):
-        question = self.question
-        url = reverse('admin:control_question_change', args=[question.pk])
-        return mark_safe(f'<a href="{url}">{question}</a>')
-    question_display.fget.short_description = 'question'
-
-    @property
-    def questionnaire_display(self):
-        is_empty = not self.question.theme or not self.question.theme.questionnaire
-        if is_empty:
-            return '-'
-        questionnaire = self.question.theme.questionnaire
-        url = reverse('admin:control_questionnaire_change', args=[questionnaire.pk])
-        return mark_safe(f'<a href="{url}">{questionnaire}</a>')
-    questionnaire_display.fget.short_description = 'questionnaire'
-
-    @property
-    def control_display(self):
-        is_empty = (
-            not self.question.theme or
-            not self.question.theme.questionnaire or
-            not self.question.theme.questionnaire.control
-        )
-        if is_empty:
-            return '-'
-        control = self.question.theme.questionnaire.control
-        url = reverse('admin:control_control_change', args=[control.pk])
-        return mark_safe(f'<a href="{url}">{control}</a>')
-    control_display.fget.short_description = 'control'
-
     def __str__(self):
         return f'id {self.id} - {self.file_name}'
 

--- a/control/models.py
+++ b/control/models.py
@@ -175,7 +175,7 @@ class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - Q{self.numbering} - {self.title}'
+        return f'id {self.id} - C{self.control.id}-Q{self.numbering} - {self.title}'
 
 
 class Theme(OrderedModel, WithNumberingMixin):
@@ -191,7 +191,7 @@ class Theme(OrderedModel, WithNumberingMixin):
         verbose_name_plural = "Thèmes"
 
     def __str__(self):
-        return f'id {self.id} - Q{self.questionnaire.numbering}-T{self.numbering} - {self.title}'
+        return f'id {self.id} - C{self.questionnaire.control.id}-Q{self.questionnaire.numbering}-T{self.numbering} - {self.title}'
 
 
 class Question(OrderedModel, WithNumberingMixin, DocxMixin):
@@ -211,7 +211,7 @@ class Question(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - Q{self.theme.questionnaire.numbering}-T{self.theme.numbering}-{self.numbering} - {self.description}'
+        return f'id {self.id} - C{self.theme.questionnaire.control.id}-Q{self.theme.questionnaire.numbering}-T{self.theme.numbering}-{self.numbering} - {self.description}'
 
 
 class QuestionFile(OrderedModel, FileInfoMixin):

--- a/control/models.py
+++ b/control/models.py
@@ -206,7 +206,7 @@ class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - {self.title_display}'
+        return f'id {self.id} - Q{self.numbering} - {self.title}'
 
 
 class Theme(OrderedModel, WithNumberingMixin):
@@ -222,7 +222,7 @@ class Theme(OrderedModel, WithNumberingMixin):
         verbose_name_plural = "Thèmes"
 
     def __str__(self):
-        return f'id {self.id} - T{self.numbering} - {self.title}'
+        return f'id {self.id} - Q{self.questionnaire.numbering}-T{self.numbering} - {self.title}'
 
 
 class Question(OrderedModel, WithNumberingMixin, DocxMixin):
@@ -242,7 +242,7 @@ class Question(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - Q{self.numbering} - {self.description}'
+        return f'id {self.id} - Q{self.theme.questionnaire.numbering}-T{self.theme.numbering}-{self.numbering} - {self.description}'
 
 
 class QuestionFile(OrderedModel, FileInfoMixin):

--- a/control/models.py
+++ b/control/models.py
@@ -71,8 +71,8 @@ class Control(models.Model):
         error_messages={'unique': UNIQUE_ERROR_MESSAGE})
 
     class Meta:
-        verbose_name = "Controle"
-        verbose_name_plural = "Controles"
+        verbose_name = "Contrôle"
+        verbose_name_plural = "Contrôles"
 
     def data(self):
         return {
@@ -122,7 +122,7 @@ class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
         help_text=(
             "Ce fichier est généré automatiquement quand le questionnaire est enregistré."))
     control = models.ForeignKey(
-        to='Control', verbose_name='controle', related_name='questionnaires',
+        to='Control', verbose_name='contrôle', related_name='questionnaires',
         null=True, blank=True, on_delete=models.CASCADE)
     order_with_respect_to = 'control'
     order = models.PositiveIntegerField('order', db_index=True)

--- a/control/models.py
+++ b/control/models.py
@@ -206,7 +206,7 @@ class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - {self.title_display}'
+        return f'id {self.id} - Q{self.numbering} - {self.title}'
 
 
 class Theme(OrderedModel, WithNumberingMixin):
@@ -222,7 +222,7 @@ class Theme(OrderedModel, WithNumberingMixin):
         verbose_name_plural = "Thèmes"
 
     def __str__(self):
-        return f'id {self.id} - {self.title}'
+        return f'id {self.id} - T{self.numbering} - {self.title}'
 
 
 class Question(OrderedModel, WithNumberingMixin, DocxMixin):

--- a/control/models.py
+++ b/control/models.py
@@ -41,7 +41,7 @@ class FileInfoMixin(object):
     def question_display(self):
         question = self.question
         url = reverse('admin:control_question_change', args=[question.pk])
-        return mark_safe(f'<a href="{url}">{question.numbering}. {question}</a>')
+        return mark_safe(f'<a href="{url}">{question}</a>')
     question_display.fget.short_description = 'question'
 
     @property
@@ -206,7 +206,7 @@ class Questionnaire(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - Q{self.numbering} - {self.title}'
+        return f'id {self.id} - {self.title_display}'
 
 
 class Theme(OrderedModel, WithNumberingMixin):
@@ -242,7 +242,7 @@ class Question(OrderedModel, WithNumberingMixin, DocxMixin):
         return self.to_rich_text(self.description)
 
     def __str__(self):
-        return f'id {self.id} - {self.description}'
+        return f'id {self.id} - Q{self.numbering} - {self.description}'
 
 
 class QuestionFile(OrderedModel, FileInfoMixin):

--- a/logs/admin.py
+++ b/logs/admin.py
@@ -55,7 +55,7 @@ class ActionAdmin(ReadOnlyModelAdmin, admin.ModelAdmin):
     list_display = (
         '__str__', actor_display, 'verb', target_display, 'target_content_type',
         action_object_display, 'action_object_content_type', 'timestamp')
-    list_filter = ('timestamp', 'verb', 'target_object_id')
+    list_filter = ('timestamp', 'verb', 'actor_object_id', 'target_object_id')
     fieldsets = (
         (None, {
             'fields': ('verb', 'timestamp', 'description')

--- a/logs/admin.py
+++ b/logs/admin.py
@@ -55,7 +55,7 @@ class ActionAdmin(ReadOnlyModelAdmin, admin.ModelAdmin):
     list_display = (
         '__str__', actor_display, 'verb', target_display, 'target_content_type',
         action_object_display, 'action_object_content_type', 'timestamp')
-    list_filter = ('timestamp', 'verb',)
+    list_filter = ('timestamp', 'verb', 'target_object_id')
     fieldsets = (
         (None, {
             'fields': ('verb', 'timestamp', 'description')

--- a/logs/admin.py
+++ b/logs/admin.py
@@ -55,7 +55,7 @@ class ActionAdmin(ReadOnlyModelAdmin, admin.ModelAdmin):
     list_display = (
         '__str__', actor_display, 'verb', target_display, 'target_content_type',
         action_object_display, 'action_object_content_type', 'timestamp')
-    list_filter = ('timestamp', 'verb', 'actor_object_id', 'target_object_id')
+    list_filter = ('timestamp', 'verb')
     fieldsets = (
         (None, {
             'fields': ('verb', 'timestamp', 'description')

--- a/templates/admin/actstream/action/search_form.html
+++ b/templates/admin/actstream/action/search_form.html
@@ -1,0 +1,49 @@
+{% load i18n static %}
+
+<!-- Place description text here, to be displayed above search bar. -->
+<div>
+  Pour trouver toutes les actions liées à :
+  <ul>
+    <li>
+     l'<strong>utilisateur</strong> dont l'ID est 123:
+      <code>/actstream/action/?actor_object_id=123</code>
+    </li>
+    <li>
+      le <strong>controle</strong> dont l'ID est 456:
+      <code>/actstream/action/?target_object_id=456</code>
+    </li>
+    <li>
+      les deux :
+      <code>/actstream/action/?actor_object_id=123&target_object_id=456</code>
+    </li>
+
+  </ul>
+</div>
+<div>
+  Comment trouver l'ID d'un objet ?
+</div>
+<div>
+  Aller à la page de l'objet et regarder le numéro dans l'URL.
+</div>
+<div>
+  Exemple : trouver l'ID du contrôle "CCG de Blablabla". Je vais sur la page du CCG de Blablabla dans l'admin.
+  L'URL est : <code>/control/control/37/change/</code>. L'ID est donc 37.
+</div>
+
+<!-- Original search field below. Do not edit. -->
+
+{% if cl.search_fields %}
+<div id="toolbar"><form id="changelist-search" method="get">
+<div><!-- DIV needed for valid HTML -->
+<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus>
+<input type="submit" value="{% trans 'Search' %}">
+{% if show_result_count %}
+    <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>
+{% endif %}
+{% for pair in cl.params.items %}
+    {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}">{% endif %}
+{% endfor %}
+</div>
+</form></div>
+{% endif %}

--- a/templates/admin/auth/search_form.html
+++ b/templates/admin/auth/search_form.html
@@ -1,0 +1,1 @@
+{% extends "admin/user_profiles/userprofile/search_form.html" %}

--- a/templates/admin/user_profiles/userprofile/search_form.html
+++ b/templates/admin/user_profiles/userprofile/search_form.html
@@ -2,15 +2,22 @@
 
 <!-- Place description text here, to be displayed above search bar. -->
 <div>
-  Pour trouver <strong>tous les utilisateurs du contrôle</strong> dont l'ID est 123:
+  Vous pouvez limiter la liste des utilisateurs pour un certain contrôle.
+  Il suffit de regarder la zone "FILTRE" de cette page et d'utiliser
+  le filtre <strong>Par contrôles</strong>.
+</div>
+<br>
+<div>
+  Si vous connessez déjà l'ID d'un contrôle, par exemple '123', et que vous voulez
+  trouver <strong>tous les utilisateurs de ce contrôle</strong> :
   <code>/user_profiles/userprofile/?controls__id__exact=123</code>
 </div>
 <br>
 <div>
-  Comment trouver l'ID d'un objet ?
+  Comment trouver l'ID d'un objet, par exemple d'un contrôle ?
 </div>
 <div>
-  Aller à la page de l'objet et regarder le numéro dans l'URL.
+  Aller à la page de cet objet et regarder le numéro dans l'URL.
 </div>
 <div>
   Exemple : trouver l'ID du contrôle "CCG de Blablabla". Je vais sur la page du CCG de Blablabla dans l'admin.

--- a/templates/admin/user_profiles/userprofile/search_form.html
+++ b/templates/admin/user_profiles/userprofile/search_form.html
@@ -1,0 +1,36 @@
+{% load i18n static %}
+
+<!-- Place description text here, to be displayed above search bar. -->
+<div>
+  Pour trouver <strong>tous les utilisateurs du contrôle</strong> dont l'ID est 123:
+  <code>/user_profiles/userprofile/?controls__id__exact=123</code>
+</div>
+<br>
+<div>
+  Comment trouver l'ID d'un objet ?
+</div>
+<div>
+  Aller à la page de l'objet et regarder le numéro dans l'URL.
+</div>
+<div>
+  Exemple : trouver l'ID du contrôle "CCG de Blablabla". Je vais sur la page du CCG de Blablabla dans l'admin.
+  L'URL est : <code>/control/control/37/change/</code>. L'ID est donc 37.
+</div>
+
+<!-- Original search field below. Do not edit. -->
+
+{% if cl.search_fields %}
+<div id="toolbar"><form id="changelist-search" method="get">
+<div><!-- DIV needed for valid HTML -->
+<label for="searchbar"><img src="{% static "admin/img/search.svg" %}" alt="Search"></label>
+<input type="text" size="40" name="{{ search_var }}" value="{{ cl.query }}" id="searchbar" autofocus>
+<input type="submit" value="{% trans 'Search' %}">
+{% if show_result_count %}
+    <span class="small quiet">{% blocktrans count counter=cl.result_count %}{{ counter }} result{% plural %}{{ counter }} results{% endblocktrans %} (<a href="?{% if cl.is_popup %}_popup=1{% endif %}">{% if cl.show_full_result_count %}{% blocktrans with full_result_count=cl.full_result_count %}{{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)</span>
+{% endif %}
+{% for pair in cl.params.items %}
+    {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}">{% endif %}
+{% endfor %}
+</div>
+</form></div>
+{% endif %}

--- a/user_profiles/admin.py
+++ b/user_profiles/admin.py
@@ -22,6 +22,7 @@ class UserProfileInline(admin.StackedInline):
 
 class UserAdmin(BaseUserAdmin):
     inlines = (UserProfileInline,)
+    list_filter = ('profile__profile_type', 'profile__controls')
 
 
 admin.site.unregister(User)

--- a/user_profiles/admin.py
+++ b/user_profiles/admin.py
@@ -17,6 +17,7 @@ class UserProfileInline(admin.StackedInline):
     model = UserProfile
     can_delete = False
     verbose_name_plural = 'Profile Utilisateurs'
+    filter_horizontal = ('controls',)
 
 
 class UserAdmin(BaseUserAdmin):


### PR DESCRIPTION
 - Added ids in display strings (__str__ functions)
 - added a column for ID in all pages, generally tried to harmonize various pages to display the same data in the same place
 - displayed parents of objects in table views (e.g. for a question, add columns for theme, questionnaire, control) with hyperlinks
 - in control page, added users associated to the control
 - added instructions for how to search in the action page (how to use the fancy url query params). I added it by overriding a piece of admin template.