### PR TITLE
Soft Delete Backend (3): Filter out on API endpoints when control is deleted

### DIFF
--- a/control/api_views.py
+++ b/control/api_views.py
@@ -41,7 +41,7 @@ class ControlViewSet(viewsets.ModelViewSet):
 
     def create(self, request, *args, **kwargs):
         response = super(ControlViewSet, self).create(request, *args, **kwargs)
-        control = Control.objects.get(id=response.data['id'])
+        control = self.get_queryset().get(id=response.data['id'])
         # The current user is automatically added to the created control
         self.request.user.profile.controls.add(control)
         self.add_log_entry(control=control, verb='created control')
@@ -49,7 +49,7 @@ class ControlViewSet(viewsets.ModelViewSet):
 
     def update(self, request, *args, **kwargs):
         response = super(ControlViewSet, self).update(request, *args, **kwargs)
-        control = Control.objects.get(id=response.data['id'])
+        control = self.get_queryset().get(id=response.data['id'])
         self.add_log_entry(control=control, verb='updated control')
         return response
 
@@ -59,7 +59,7 @@ class QuestionViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         queryset = Question.objects.filter(
-            theme__questionnaire__control__in=self.request.user.profile.controls.all())
+            theme__questionnaire__control__in=self.request.user.profile.controls.active())
         return queryset
 
     def list(self, request, *args, **kwargs):
@@ -147,7 +147,7 @@ class ThemeViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         queryset = Theme.objects.filter(
-            questionnaire__control__in=self.request.user.profile.controls.all())
+            questionnaire__control__in=self.request.user.profile.controls.active())
         return queryset
 
 

--- a/control/tests/test_api.py
+++ b/control/tests/test_api.py
@@ -13,6 +13,7 @@ client = APIClient()
 def get_theme(user, id):
     return utils.get_resource(client, user, 'theme', id)
 
+
 def test_can_access_theme_api_if_control_is_associated_with_the_user():
     theme = factories.ThemeFactory()
     user = utils.make_audited_user(theme.questionnaire.control)
@@ -49,6 +50,13 @@ def test_can_update_theme_order():
 
     assert response.status_code == 200
     assert response.data['order'] == str(new_order)
+
+
+def test_no_access_to_theme_for_deleted_control():
+    theme = factories.ThemeFactory()
+    user = utils.make_audited_user(theme.questionnaire.control)
+    theme.questionnaire.control.delete()
+    assert get_theme(user, theme.id).status_code == 404
 
 
 #### Question API ####
@@ -88,6 +96,13 @@ def test_response_file_listed_in_question_endpoint():
     assert response_file.basename in str(response.content)
 
 
+def test_no_access_to_question_api_for_deleted_control():
+    question = factories.QuestionFactory()
+    user = utils.make_audited_user(question.theme.questionnaire.control)
+    question.theme.questionnaire.control.delete()
+    assert get_question(user, question.id).status_code == 404
+
+
 #### Control API ####
 
 ### Get
@@ -112,6 +127,13 @@ def test_no_access_to_control_get_api_for_anonymous():
     control = factories.ControlFactory()
     response = utils.get_resource_without_login(client, 'control', control.id)
     assert response.status_code == 403
+
+
+def test_no_access_to_deleted_control():
+    control = factories.ControlFactory()
+    user = utils.make_audited_user(control)
+    control.delete()
+    assert get_control(user, control.id).status_code == 404
 
 
 ### Create
@@ -210,3 +232,10 @@ def test_no_access_to_control_update_api_for_anonymous():
     url = reverse('api:control-detail', args=[control.id])
     response = client.put(url, make_update_payload(), format='json')
     assert response.status_code == 403
+
+
+def test_no_access_to_control_update_api_if_deleted():
+    control = factories.ControlFactory()
+    user = utils.make_inspector_user(control)
+    control.delete()
+    assert update_control(user, make_update_payload(), control).status_code == 404


### PR DESCRIPTION
- API for upating should not work for deleted control
- API for questions and themes should not work neither