### PR TITLE
Remove ids from user interface

### DIFF
--- a/templates/user_profiles/email_add_user.html
+++ b/templates/user_profiles/email_add_user.html
@@ -6,7 +6,7 @@
 <br/>
 - Profil : {{ target_user.profile.get_profile_type_display }}
 <br/>
-- Espace de dépôt : {{ control }}
+- Espace de dépôt : {{ control.title_display }}
 <hr/>
 <p class="text-bold">
   Pensez à inviter la nouvelle personne à se connecter à e.contrôle.
@@ -17,7 +17,7 @@
 <p class="text-justify">
 Bonjour {{ target_user.first_name }} {{ target_user.last_name }},
 <br/>
-Dans le cadre de la procédure "{{ control }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur https://{{ site.domain }}.
+Dans le cadre de la procédure "{{ control.title_display }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur https://{{ site.domain }}.
 <br/>
 Cordialement,
 </p>

--- a/templates/user_profiles/email_add_user.txt
+++ b/templates/user_profiles/email_add_user.txt
@@ -4,7 +4,7 @@ Bonjour,
 
 - {{ target_user.first_name }} {{ target_user.last_name }}, {{ target_user.email }}
 - Profil : {{ target_user.profile.get_profile_type_display }}
-- Espace de dépôt : {{ control }}
+- Espace de dépôt : {{ control.title_display }}
 
 * * *
 
@@ -13,7 +13,7 @@ Voici un message type:
 
 * * *
 Bonjour {{ target_user.first_name }} {{ target_user.last_name }},
-Dans le cadre de la procédure "{{ control }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur https://{{ site.domain }}.
+Dans le cadre de la procédure "{{ control.title_display }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur https://{{ site.domain }}.
 Cordialement,
 * * *
 

--- a/templates/user_profiles/email_remove_user.html
+++ b/templates/user_profiles/email_remove_user.html
@@ -6,7 +6,7 @@
 <br/>
  - Profil : {{ target_user.profile.get_profile_type_display }}
 <br/>
- - Espace de dépôt : {{ control }}
+ - Espace de dépôt : {{ control.title_display }}
 
 <hr/>
 

--- a/templates/user_profiles/email_remove_user.txt
+++ b/templates/user_profiles/email_remove_user.txt
@@ -4,7 +4,7 @@ Bonjour,
 
 - {{ target_user.first_name }} , {{ target_user.email }}
 - Profil : {{ target_user.profile.get_profile_type_display }}
-- Espace de dépôt : {{ control }}
+- Espace de dépôt : {{ control.title_display }}
 
 
 Si vous pensez ne pas être le bon destinataire de ce message, merci de nous informer en répondant directement à cet email.


### PR DESCRIPTION
Do not use the __str__ function to display models to users, because it contains "id XXX".

The only templates I have found that use this are two email templates, and the Vue code should not be impacted.