### PR TITLE
Add rel attribute on links opening in new tabs

### DIFF
--- a/static/src/controls/WebdavTip.vue
+++ b/static/src/controls/WebdavTip.vue
@@ -64,9 +64,11 @@
             <i class="fa fa-play-circle mr-1"></i>
             Suivez les instructions en vidéo
           </button>
-          <a target="_blank" href="https://github.com/betagouv/e-controle/raw/develop/docs/guides/e-controle-explorateur-de-fichiers.pdf"
-              class="btn btn-primary"
-              title="Suivez les instructions en images."
+          <a target="_blank"
+             rel="noopener noreferrer"
+             href="https://github.com/betagouv/e-controle/raw/develop/docs/guides/e-controle-explorateur-de-fichiers.pdf"
+             class="btn btn-primary"
+             title="Suivez les instructions en images."
           >
             <i class="fe fe-image mr-1"></i>
             Suivez les instructions en images

--- a/static/src/questionnaires/PublishFlow.vue
+++ b/static/src/questionnaires/PublishFlow.vue
@@ -67,6 +67,7 @@
                   $refs.modalFlow.error.message"
             class="text-nowrap"
             target="_blank"
+            rel="noopener noreferrer"
         >
           {{ config.support_team_email }}
         </a>

--- a/static/src/questionnaires/QuestionnaireMetadata.vue
+++ b/static/src/questionnaires/QuestionnaireMetadata.vue
@@ -22,6 +22,7 @@
           <a class="btn btn-primary"
              :href="exportUrl"
              target="_blank"
+             rel="noopener noreferrer"
              title="Exporter ce questionnaire">
             <i class="fe fe-file-text mr-2"></i>Exporter ce questionnaire
           </a>

--- a/static/src/questions/ResponseFileList.vue
+++ b/static/src/questions/ResponseFileList.vue
@@ -20,7 +20,11 @@
               <div class="small text-muted">{{  file.creation_time }}</div>
             </td>
             <td>
-              <div><a target="_blank" :href="file.url">{{ file.basename }}</a></div>
+              <div>
+                <a target="_blank" rel="noopener noreferrer" :href="file.url">
+                  {{ file.basename }}
+                </a>
+              </div>
             </td>
             <td>
               <div>{{ file.author.first_name }} {{ file.author.last_name }}</div>

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -50,7 +50,8 @@
         <div class="mt-2">
           Vous pouvez essayer de recharger la page, ou
           <a :href="'mailto:' + errorEmailLink + JSON.stringify(error)"
-            target="_blank"
+             target="_blank"
+             rel="noopener noreferrer"
           >
             cliquez ici pour nous contacter
           </a>.

--- a/templates/ecc/trash.html
+++ b/templates/ecc/trash.html
@@ -45,7 +45,11 @@
               <div>{{ response_file.deletion_date }}</div>
             </td>
             <td>
-              <div><a target="_blank" href="{{ response_file.url }}">{{ response_file.basename }}</a></div>
+              <div>
+                <a target="_blank" rel="noopener noreferrer" href="{{ response_file.url }}">
+                  {{ response_file.basename }}
+                </a>
+              </div>
             </td>
             <td>
               <div>{{ response_file.deletion_user.first_name }} {{ response_file.deletion_user.last_name }}</div>

--- a/tos/templates/tos/tos.html
+++ b/tos/templates/tos/tos.html
@@ -47,7 +47,7 @@
         <p>
           La liaison avec l’application e.contrôle s'effectue au moyen d'un protocole sécurisé
           depuis le site
-          <a href="https://e-controles-beta.ccomptes.fr/" target="_blank">
+          <a href="https://e-controles-beta.ccomptes.fr/" target="_blank" rel="noopener noreferrer">
             https://e-controles-beta.ccomptes.fr/
           </a>
         </p>
@@ -124,9 +124,13 @@
           Il appartient par ailleurs à l’utilisateur de s’assurer du bon fonctionnement de son
           matériel et de son réseau. L’utilisateur doit être conscient des limites de sécurité de
           son poste de travail. Il peut se référer aux bonnes pratiques présentées sur le
-          site <a href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/" target="_blank">
-            http://www.ssi.gouv.fr/administration/bonnes-pratiques/.
+          site
+          <a href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
+             target="_blank"
+             rel="noopener noreferrer">
+            http://www.ssi.gouv.fr/administration/bonnes-pratiques/
           </a>
+          .
         </p>
       </div>
 


### PR DESCRIPTION
Add `rel="noopener noreferrer"` on links opening in new tabs, for external links.
I added it for internal links only, it doesn't hurt.