### PR TITLE
Restrict querying users

### DIFF
--- a/control/api_views.py
+++ b/control/api_views.py
@@ -1,9 +1,11 @@
 from actstream import action
 from functools import partial
 from rest_framework import generics, mixins, status, viewsets
+from rest_framework import serializers
+from rest_framework import decorators
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.parsers import FormParser, MultiPartParser
-from rest_framework import serializers
+from rest_framework.response import Response
 
 import django.dispatch
 from django.core.files import File
@@ -14,6 +16,7 @@ from control.permissions import ControlIsNotDeleted, QuestionnaireIsDraft
 from control.permissions import OnlyInspectorCanChange, ChangeQuestionnairePermission
 from .serializers import QuestionSerializer, QuestionUpdateSerializer, QuestionnaireSerializer, QuestionnaireUpdateSerializer
 from .serializers import ThemeSerializer, QuestionFileSerializer, ResponseFileSerializer, ResponseFileTrashSerializer
+from user_profiles.serializers import UserProfileSerializer
 
 
 # This signal is triggered after the questionnaire is saved via the API
@@ -55,6 +58,11 @@ class ControlViewSet(mixins.CreateModelMixin,
         control = self.get_queryset().get(id=response.data['id'])
         self.add_log_entry(control=control, verb='updated control')
         return response
+
+    @decorators.action(detail=True, methods=['get'], url_path='users')
+    def users(self, request, pk):
+        serialized_users = UserProfileSerializer(self.get_object().user_profiles.all(), many=True)
+        return Response(serialized_users.data)
 
 
 class QuestionViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):

--- a/static/src/editors/SwapEditorModal.vue
+++ b/static/src/editors/SwapEditorModal.vue
@@ -97,13 +97,10 @@ export default Vue.extend({
   },
   methods: {
     getUsers() {
-      Vue.axios.get(backendUrls.user(), {
-        params: {
-          controls: this.controlId,
-        },
-      }).then((response) => {
-        this.users = response.data
-      })
+      Vue.axios.get('/api/control/' + this.controlId + '/users/') // todo use backend.js
+        .then((response) => {
+          this.users = response.data
+        })
     },
     inspectorUsers() {
       return this.users.filter(item => {

--- a/static/src/editors/SwapEditorModal.vue
+++ b/static/src/editors/SwapEditorModal.vue
@@ -75,10 +75,8 @@ import ContactSupport from '../utils/ContactSupport'
 import EditorList from './EditorList'
 import ErrorBar from '../utils/ErrorBar'
 import Vue from 'vue'
-import VueAxios from 'vue-axios'
 import Vuex from 'vuex'
 
-Vue.use(VueAxios, axios)
 Vue.use(Vuex)
 
 export default Vue.extend({
@@ -97,7 +95,7 @@ export default Vue.extend({
   },
   methods: {
     getUsers() {
-      Vue.axios.get('/api/control/' + this.controlId + '/users/') // todo use backend.js
+      axios.get(backendUrls.getUsersInControl(this.controlId))
         .then((response) => {
           this.users = response.data
         })

--- a/static/src/users/UserSection.vue
+++ b/static/src/users/UserSection.vue
@@ -81,7 +81,7 @@ export default Vue.extend({
   },
   methods: {
     getUsers() {
-      axios.get('/api/control/' + this.control.id + '/users/') // todo use backend.js
+      axios.get(backendUrls.getUsersInControl(this.control.id))
         .then((response) => {
           this.users = response.data
         })

--- a/static/src/users/UserSection.vue
+++ b/static/src/users/UserSection.vue
@@ -11,7 +11,10 @@
     <div class="card-body">
       <div class="card">
         <div class="card-header justify-content-between">
-          <h3 class="card-title"><i class="fa fa-university mr-2"></i><strong>Équipe de contrôle</strong></h3>
+          <h3 class="card-title">
+            <i class="fa fa-university mr-2"></i>
+            <strong>Équipe de contrôle</strong>
+          </h3>
           <a v-if="sessionUser.is_inspector"
              href="javascript:void(0)"
              data-toggle="modal"
@@ -22,12 +25,16 @@
             Ajouter un contrôleur
           </a>
         </div>
-        <user-list :users="inspectorUsers()" profile-type="inspector" :control="control"></user-list>
+        <user-list :users="inspectorUsers()" profile-type="inspector" :control="control">
+        </user-list>
       </div>
 
       <div class="card mb-0">
         <div class="card-header justify-content-between">
-          <h3 class="card-title"><i class="fa fa-building mr-2"></i><strong>Organisme interrogé</strong></h3>
+          <h3 class="card-title">
+            <i class="fa fa-building mr-2"></i>
+            <strong>Organisme interrogé</strong>
+          </h3>
           <a v-if="sessionUser.is_inspector"
              href=""
              data-toggle="modal"
@@ -38,7 +45,8 @@
             Ajouter une personne
           </a>
         </div>
-        <user-list :users="auditedUsers()" profile-type="audited" :control="control"></user-list>
+        <user-list :users="auditedUsers()" profile-type="audited" :control="control">
+        </user-list>
       </div>
     </div>
   </div>
@@ -46,73 +54,66 @@
 </template>
 
 <script lang="ts">
-  import { mapFields } from 'vuex-map-fields'
-  import axios from "axios"
-  import Vue from "vue";
-  import VueAxios from "vue-axios"
+import axios from 'axios'
+import backendUrls from '../utils/backend'
+import EventBus from '../events'
+import { mapFields } from 'vuex-map-fields'
+import { store } from '../store'
+import UserList from './UserList'
+import Vue from 'vue'
 
-  import { store } from '../store'
-  import CollapsibleSection from '../utils/CollapsibleSection'
-  import EventBus from '../events'
-  import UserList from "./UserList"
-
-
-  Vue.use(VueAxios, axios)
-
-
-  export default Vue.extend({
-    store,
-    props: {
-      control: Object,
-    },
-    data() {
-      return {
-        users: []
-      }
-    },
-    computed: {
-      ...mapFields([
-        'editingControl',
-        'editingProfileType',
-        'sessionUser',
-      ]),
-    },
-    methods: {
-      getUsers() {
-        Vue.axios.get('/api/user/', {
-          params: {
-            controls: this.control.id
-          }
-        }).then((response) => {
-          this.users = response.data
-        })
-      },
-      auditedUsers() {
-        return this.users.filter(item => {
-           return item.profile_type === 'audited'
-        })
-      },
-      inspectorUsers() {
-        return this.users.filter(item => {
-           return item.profile_type === 'inspector'
-        })
-      },
-      updateEditingState(profileType) {
-        this.editingControl = this.control
-        this.editingProfileType = profileType
-      }
-    },
-    mounted() {
-      this.getUsers()
-      EventBus.$on('users-changed', () => {
-        this.getUsers()
+export default Vue.extend({
+  store,
+  props: {
+    control: Object,
+  },
+  data() {
+    return {
+      users: [],
+    }
+  },
+  computed: {
+    ...mapFields([
+      'editingControl',
+      'editingProfileType',
+      'sessionUser',
+    ]),
+  },
+  methods: {
+    getUsers() {
+      axios.get(backendUrls.user(), {
+        params: {
+          controls: this.control.id,
+        },
+      }).then((response) => {
+        this.users = response.data
       })
     },
-    components: {
-      CollapsibleSection,
-      UserList,
-    }
-  });
+    auditedUsers() {
+      return this.users.filter(item => {
+        return item.profile_type === 'audited'
+      })
+    },
+    inspectorUsers() {
+      return this.users.filter(item => {
+        return item.profile_type === 'inspector'
+      })
+    },
+    updateEditingState(profileType) {
+      this.editingControl = this.control
+      this.editingProfileType = profileType
+    },
+  },
+  mounted() {
+    this.getUsers()
+    EventBus.$on('users-changed', () => {
+      this.getUsers()
+    })
+  },
+  components: {
+    UserList,
+  },
+})
 </script>
 
 <style></style>

--- a/static/src/users/UserSection.vue
+++ b/static/src/users/UserSection.vue
@@ -81,13 +81,10 @@ export default Vue.extend({
   },
   methods: {
     getUsers() {
-      axios.get(backendUrls.user(), {
-        params: {
-          controls: this.control.id,
-        },
-      }).then((response) => {
-        this.users = response.data
-      })
+      axios.get('/api/control/' + this.control.id + '/users/') // todo use backend.js
+        .then((response) => {
+          this.users = response.data
+        })
     },
     auditedUsers() {
       return this.users.filter(item => {

--- a/static/src/utils/backend.js
+++ b/static/src/utils/backend.js
@@ -51,6 +51,7 @@ for (const [name, url] of Object.entries(apiUrls)) {
 }
 
 urlMaker.currentUser = () => '/api/user/current/'
+urlMaker.getUsersInControl = (controlId) => '/api/control/' + controlId + '/users/'
 urlMaker.removeUserFromControl = (id) => '/api/user/' + id + '/remove-control/'
 urlMaker.swapEditor = (questionnaireId) =>
   '/api/questionnaire/' + questionnaireId + '/changer-redacteur/'

--- a/user_profiles/api_views.py
+++ b/user_profiles/api_views.py
@@ -18,7 +18,6 @@ class UserProfileViewSet(
         mixins.ListModelMixin,
         viewsets.GenericViewSet):
     serializer_class = UserProfileSerializer
-    filterset_fields = ('controls',)
     search_fields = ('=user__username',)
     permission_classes = (OnlyInspectorCanChange,)
 

--- a/user_profiles/api_views.py
+++ b/user_profiles/api_views.py
@@ -18,7 +18,7 @@ class UserProfileViewSet(
         mixins.ListModelMixin,
         viewsets.GenericViewSet):
     serializer_class = UserProfileSerializer
-    filterset_fields = ('controls', 'profile_type')
+    filterset_fields = ('controls',)
     search_fields = ('=user__username',)
     permission_classes = (OnlyInspectorCanChange,)
 


### PR DESCRIPTION
On a des problemes avec `/api/users/?control=123`. Le filtrage est compliqué dans le cas où le control existe, mais n'est pas accessible au user.

Je propose de supprimer cette action, et d'utiliser à la place `/api/control/123/users`. 
C'est plus simple parce que ca reutilise les permissions et le queryset du ControlViewSet. Comme ca on fait pas de filtrage compliqué, et les permissions+queryset sont definies une seule fois. Plus c'est simple, moins on a de problèmes!

J'ai aussi supprimé le endpoint pour filtrer les users par profile_type, c'était pas utilisé dans le frontend.