### PR TITLE
Refactor questonnaire permission

### DIFF
--- a/control/api_views.py
+++ b/control/api_views.py
@@ -13,7 +13,7 @@ from django.core.files import File
 from .models import Control, Question, Questionnaire, Theme, QuestionFile, ResponseFile
 from .serializers import ControlSerializer, ControlUpdateSerializer
 from control.permissions import ControlIsNotDeleted, QuestionnaireIsDraft
-from control.permissions import OnlyInspectorCanChange, ChangeQuestionnairePermission
+from control.permissions import OnlyInspectorCanChange, OnlyEditorCanChangeQuestionnaire
 from .serializers import QuestionSerializer, QuestionUpdateSerializer, QuestionnaireSerializer, QuestionnaireUpdateSerializer
 from .serializers import ThemeSerializer, QuestionFileSerializer, ResponseFileSerializer, ResponseFileTrashSerializer
 from user_profiles.serializers import UserProfileSerializer
@@ -157,7 +157,7 @@ class QuestionnaireViewSet(mixins.CreateModelMixin,
                            mixins.UpdateModelMixin,
                            viewsets.GenericViewSet):
     serializer_class = QuestionnaireSerializer
-    permission_classes = (ChangeQuestionnairePermission,)
+    permission_classes = (OnlyInspectorCanChange, OnlyEditorCanChangeQuestionnaire)
 
     def get_queryset(self):
         queryset = Questionnaire.objects.filter(

--- a/control/permissions.py
+++ b/control/permissions.py
@@ -24,22 +24,15 @@ class OnlyInspectorCanChange(permissions.BasePermission):
         return request.user.profile.is_inspector
 
 
-class ChangeQuestionnairePermission(OnlyInspectorCanChange):
+class OnlyEditorCanChangeQuestionnaire(permissions.BasePermission):
 
-    def has_permission(self, request, view):
-        if not super(ChangeQuestionnairePermission, self).has_permission(request, view):
-            return False
-        if request.parser_context.get('kwargs') is None or request.parser_context['kwargs'].get('pk') is None:
-            return True
-        questionnaire_id = request.parser_context['kwargs']['pk']
-        questionnaire = Questionnaire.objects.get(id=questionnaire_id)
-        if not questionnaire.editor:
-            return False
-        if not questionnaire.is_draft:
-            return True
+    def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True
-        if questionnaire.editor.pk == request.user.pk:
+        questionnaire = obj
+        if not questionnaire.editor:
+            return False
+        if questionnaire.editor == request.user:
             return True
         return False
 


### PR DESCRIPTION
- The permission is now split into several classes
- We introduce a permission that checks that only the questionnaire's
editor can change
- We are now usin a object level permission, so there's no need to check
for the `pk` in args