### PR TITLE
Revert removal of vue-axios

### DIFF
--- a/static/src/editors/SwapEditorModal.vue
+++ b/static/src/editors/SwapEditorModal.vue
@@ -75,8 +75,10 @@ import ContactSupport from '../utils/ContactSupport'
 import EditorList from './EditorList'
 import ErrorBar from '../utils/ErrorBar'
 import Vue from 'vue'
+import VueAxios from 'vue-axios'
 import Vuex from 'vuex'
 
+Vue.use(VueAxios, axios)
 Vue.use(Vuex)
 
 export default Vue.extend({


### PR DESCRIPTION
Revert the removal of Vue-axios. It was done only partially, which caused a problem. In next release we are removing vue-axios completely, so this will disappear.

(this is a bugfix on release branch, so I am opting for the smallest change possible, so that we don't have to re-test the interface)