### PR TITLE
Bugfix : sidebar for ie

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -27,8 +27,19 @@
         display: block;
     }
 
+    /*
+    Add explicit margin for IE to fix layout
+    */
     .ie-margin-for-footer {
         margin-bottom: 30em !important;
+    }
+
+    /*
+    Flex bug in IE : sometimes children of flex-row spread out horizontally instead of having the
+    appropriate width. (It caused some pages to display wider than the screen for example)
+    */
+    .ie-flex-row-child {
+        width:100%;
     }
 }
 

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -272,7 +272,7 @@ export default Vue.extend({
     position: fixed;
     top: 90px;
     left: 350px;
-    z-index: 21;
+    z-index: 1000; /* Just above sidebar items at z-index 999, but under modals at 1050 */
     transition: left 0.3s;
   }
   .collapsed #sidebar-toggle-button {

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,7 @@
 {% endblock extra_static_header %}
 
 {% block content %}
-  <div id="page" class="page container-fluid flex-row"> <!--// opening: page  //-->
-    <div id="app"></div>
+  <div id="page" class="page container-fluid"> <!--// opening: page  //-->
     <div id="non-footer" class="flex-column flex-grow-1">
       {% block page_top_row %}
         <div class="header flex-row justify-content-between"> <!--// opening: top_header  //-->
@@ -55,7 +54,7 @@
           <sidebar></sidebar>
         </div>
 
-        <div class="mt-3 mt-md-5 flex-grow-1 ml-6">
+        <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
           {% block page_main_container %}
           {% endblock page_main_container %}
         </div>
@@ -64,7 +63,7 @@
     {% include "footer.html" %}
   </div> <!--// closing: page  //-->
 
-  <link href="{% static "dist/sidebar-bundle.css" %}" rel="stylesheet" />
+  <link href="{% static 'dist/sidebar-bundle.css' %}" rel="stylesheet" />
   <script src="{% static 'dist/sidebar-bundle.js' %}"></script>
 
 {% endblock content %}


### PR DESCRIPTION
Fixes 2 problems : 
 - when page scrolls horizontally, the sidebar button moves away from the sidebar
 -> fixed by removing the sideways scroll, which was an IE bug anyway.
 - sidebar toggle button was displayed under sidebar
 -> fixed by increasing z-index.