### PR TITLE
Bottom bar broken in IE

### DIFF
--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -260,7 +260,7 @@ export default Vue.extend({
     StickyBottomMixin,
   ],
   mounted() {
-    this.stickyBottom_makeStickyBottom('bottom-bar', 140, 103)
+    this.stickyBottom_makeStickyBottom('bottom-bar', 140, 103, 44)
 
     console.debug('questionnaireId', this.questionnaireId)
     console.debug('controlId', this.controlId)

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -61,8 +61,10 @@
     </div>
   </div>
 
+  <!-- Note : use v-show and not v-if for the bottom-bar, because the element needs to be in the DOM
+  from the start for the IE sticky-bottom to work. -->
   <div id="bottom-bar"
-       v-if="state !== STATES.LOADING"
+       v-show="state !== STATES.LOADING"
        class="flex-column bg-white sticky-bottom border-top p-4">
     <div id="button-bar" class="flex-row justify-content-between">
       <button id="go-home-button"
@@ -258,7 +260,7 @@ export default Vue.extend({
     StickyBottomMixin,
   ],
   mounted() {
-    this.stickyBottom_makeStickyBottom('bottom-bar', 140)
+    this.stickyBottom_makeStickyBottom('bottom-bar', 140, 103)
 
     console.debug('questionnaireId', this.questionnaireId)
     console.debug('controlId', this.controlId)

--- a/static/src/utils/StickyBottomMixin.js
+++ b/static/src/utils/StickyBottomMixin.js
@@ -6,14 +6,16 @@ export default {
      * @param {*} bottomOffsetPx The distance from the bottom of the page at which the element
      * should become fixed and stop scrolling.
      * @param {*} elementHeightPx (optional) If the height of the element varies, the layout will
-     * not be moved accordingly. In this case, specify the element height that you want to use.
+     * not be moved accordingly. In this case, specify the (fixed) element height that you want to
+     * use.
+     * @param {*} extraWidthPx (optional) Hack alert! If you want to make your element a bit wider.
      */
-    stickyBottom_makeStickyBottom(elementId, bottomOffsetPx, elementHeightPx) {
+    stickyBottom_makeStickyBottom(elementId, bottomOffsetPx, elementHeightPx, extraWidthPx = 0) {
       const stickySupport = this.stickyBottom_isPositionStickySupported()
       console.log('stickySupport', stickySupport)
 
       if (!stickySupport) {
-        this.stickyBottom_makeStickyByHand(elementId, bottomOffsetPx, elementHeightPx)
+        this.stickyBottom_makeStickyByHand(elementId, bottomOffsetPx, elementHeightPx, extraWidthPx)
       }
     },
     stickyBottom_isPositionStickySupported() {
@@ -39,7 +41,7 @@ export default {
       }
       setInterval(pollFunc, pollPeriodMs)
     },
-    stickyBottom_makeStickyByHand(elementId, bottomOffsetPx, elementHeightPx) {
+    stickyBottom_makeStickyByHand(elementId, bottomOffsetPx, elementHeightPx, extraWidthPx = 0) {
       const element = document.getElementById(elementId)
       if (typeof elementHeightPx === 'undefined') {
         elementHeightPx = element.offsetHeight
@@ -58,7 +60,7 @@ export default {
 
       // Set the width. Needs to change if width of page changes (window resize of change in page)
       const setWidth = () => {
-        const elementWidthPx = placeholderElement.offsetWidth
+        const elementWidthPx = placeholderElement.offsetWidth + extraWidthPx
         stickyMenu.css('min-width', elementWidthPx + 'px')
       }
       setWidth()

--- a/static/src/utils/StickyBottomMixin.js
+++ b/static/src/utils/StickyBottomMixin.js
@@ -1,11 +1,19 @@
 export default {
   methods: {
-    stickyBottom_makeStickyBottom(elementId, bottomOffsetPx) {
+    /**
+     *
+     * @param {*} elementId The HTML id of the element you want to make sticky.
+     * @param {*} bottomOffsetPx The distance from the bottom of the page at which the element
+     * should become fixed and stop scrolling.
+     * @param {*} elementHeightPx (optional) If the height of the element varies, the layout will
+     * not be moved accordingly. In this case, specify the element height that you want to use.
+     */
+    stickyBottom_makeStickyBottom(elementId, bottomOffsetPx, elementHeightPx) {
       const stickySupport = this.stickyBottom_isPositionStickySupported()
       console.log('stickySupport', stickySupport)
 
       if (!stickySupport) {
-        this.stickyBottom_makeStickyByHand(elementId, bottomOffsetPx)
+        this.stickyBottom_makeStickyByHand(elementId, bottomOffsetPx, elementHeightPx)
       }
     },
     stickyBottom_isPositionStickySupported() {
@@ -31,9 +39,11 @@ export default {
       }
       setInterval(pollFunc, pollPeriodMs)
     },
-    stickyBottom_makeStickyByHand(elementId, bottomOffsetPx) {
+    stickyBottom_makeStickyByHand(elementId, bottomOffsetPx, elementHeightPx) {
       const element = document.getElementById(elementId)
-      const elementHeightPx = element.offsetHeight
+      if (typeof elementHeightPx === 'undefined') {
+        elementHeightPx = element.offsetHeight
+      }
 
       // Create a placeholder element of the same height as the fixed element.
       const placeholderElement = document.createElement('div')


### PR DESCRIPTION
Broken in 1.16 (known issue).

It was broken because the bottom-bar on IE is made sticky by our own custom function, and that function broke because the bottom-bar was not displayed at the start (it was hidden while content was loading).
So I changed the v-if (which removes elements completely from the DOM) to a v-show (which only hides them), and added a hack to adjust the height of the element (when it's hidden, the height is 0, and that messed up the rest).

I also added a second hack for the width, because it was not stretching all the way because of negative margins... Or maybe because of flex... Who knows...  

