### PR TITLE
Move sidebar inside page bundles

### DIFF
--- a/static/src/control-detail.js
+++ b/static/src/control-detail.js
@@ -3,8 +3,8 @@ import '@babel/polyfill'
 import Vuex, { mapActions } from 'vuex'
 import Vue from 'vue/dist/vue.js'
 
-import { store } from './store'
 import ControlDetail from './controls/ControlDetail'
+import { loadStatuses, store } from './store'
 
 Vue.use(Vuex)
 
@@ -42,5 +42,8 @@ new Vue({ // eslint-disable-line no-new
   created() {
     this.fetchConfig()
     this.fetchSessionUser()
+    // Store the controls in the Vuex store, for use for other components (e.g. Sidebar)
+    this.$store.commit('updateControls', controls)
+    this.$store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
   },
 })

--- a/static/src/control-detail.js
+++ b/static/src/control-detail.js
@@ -36,14 +36,16 @@ new Vue({ // eslint-disable-line no-new
       },
     }),
   methods: {
-    ...mapActions(['fetchConfig', 'fetchSessionUser']),
-    // Todo : we don't need to both fetch session user and get it from server data.
+    ...mapActions(['fetchConfig']),
   },
   created() {
     this.fetchConfig()
-    this.fetchSessionUser()
+
     // Store the controls in the Vuex store, for use for other components (e.g. Sidebar)
     this.$store.commit('updateControls', controls)
     this.$store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+    // Store the current user in the Vuex store, for use for other components (e.g. Sidebar)
+    this.$store.commit('updateSessionUser', user)
+    this.$store.commit('updateSessionUserLoadStatus', loadStatuses.SUCCESS)
   },
 })

--- a/static/src/control-detail.js
+++ b/static/src/control-detail.js
@@ -27,18 +27,14 @@ const user = JSON.parse(userDataEl.textContent)
 new Vue({ // eslint-disable-line no-new
   store,
   el: '#control-detail-vm',
-  render: h => h(
+  components: {
     ControlDetail,
-    {
-      props: {
-        controls: controls,
-        user: user,
-      },
-    }),
+  },
   methods: {
     ...mapActions(['fetchConfig']),
   },
   created() {
+    // Ask the store to fetch the config from server and store it.
     this.fetchConfig()
 
     // Store the controls in the Vuex store, for use for other components (e.g. Sidebar)

--- a/static/src/control-detail.js
+++ b/static/src/control-detail.js
@@ -4,7 +4,7 @@ import Vuex, { mapActions } from 'vuex'
 import Vue from 'vue/dist/vue.js'
 
 import { store } from './store'
-import ControlPage from './controls/ControlPage'
+import ControlDetail from './controls/ControlDetail'
 
 Vue.use(Vuex)
 
@@ -28,7 +28,7 @@ new Vue({ // eslint-disable-line no-new
   store,
   el: '#control-detail-vm',
   render: h => h(
-    ControlPage,
+    ControlDetail,
     {
       props: {
         controls: controls,
@@ -37,7 +37,7 @@ new Vue({ // eslint-disable-line no-new
     }),
   methods: {
     ...mapActions(['fetchConfig', 'fetchSessionUser']),
-
+    // Todo : we don't need to both fetch session user and get it from server data.
   },
   created() {
     this.fetchConfig()

--- a/static/src/controls/ControlDetail.vue
+++ b/static/src/controls/ControlDetail.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="page-main flex-row">
+    <div id="sidebar-vm" class="border-right">
+      sidebar in sub template
+      <sidebar></sidebar>
+    </div>
+    <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
+      <control-page :controls="controls" :user="user">
+      </control-page>
+    </div>
+  </div>
+</template>
+
+<script>
+import ControlPage from './ControlPage'
+import { loadStatuses } from '../store'
+import Sidebar from '../utils/Sidebar'
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'ControlDetail',
+  props: [
+    'controls',
+    'user',
+  ],
+  components: {
+    ControlPage,
+    Sidebar,
+  },
+  mounted() {
+    // Store the controls in the Vuex store, for use for other components (e.g. Sidebar)
+    // this.$store exists because Vuex was initialized in the parent component.
+    this.$store.commit('updateControls', this.controls)
+    this.$store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
+  },
+})
+</script>

--- a/static/src/controls/ControlDetail.vue
+++ b/static/src/controls/ControlDetail.vue
@@ -4,7 +4,7 @@
       <sidebar></sidebar>
     </div>
     <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
-      <control-page :controls="controls" :user="user">
+      <control-page>
       </control-page>
     </div>
   </div>
@@ -17,10 +17,6 @@ import Vue from 'vue'
 
 export default Vue.extend({
   name: 'ControlDetail',
-  props: [
-    'controls',
-    'user',
-  ],
   components: {
     ControlPage,
     Sidebar,

--- a/static/src/controls/ControlDetail.vue
+++ b/static/src/controls/ControlDetail.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="page-main flex-row">
     <div id="sidebar-vm" class="border-right">
-      sidebar in sub template
       <sidebar></sidebar>
     </div>
     <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
@@ -13,7 +12,6 @@
 
 <script>
 import ControlPage from './ControlPage'
-import { loadStatuses } from '../store'
 import Sidebar from '../utils/Sidebar'
 import Vue from 'vue'
 
@@ -26,12 +24,6 @@ export default Vue.extend({
   components: {
     ControlPage,
     Sidebar,
-  },
-  mounted() {
-    // Store the controls in the Vuex store, for use for other components (e.g. Sidebar)
-    // this.$store exists because Vuex was initialized in the parent component.
-    this.$store.commit('updateControls', this.controls)
-    this.$store.commit('updateControlsLoadStatus', loadStatuses.SUCCESS)
   },
 })
 </script>

--- a/static/src/controls/ControlPage.vue
+++ b/static/src/controls/ControlPage.vue
@@ -37,16 +37,13 @@ import Vue from 'vue'
 
 import AddUserModal from '../users/AddUserModal'
 import ControlCard from './ControlCard'
+import { mapState } from 'vuex'
 import NoControls from './NoControls'
 import RemoveUserModal from '../users/RemoveUserModal'
 import UpdateUserModal from '../users/UpdateUserModal'
 
 export default Vue.extend({
   name: 'ControlPage',
-  props: [
-    'controls',
-    'user',
-  ],
   data: function() {
     return {
       hash: '',
@@ -58,6 +55,13 @@ export default Vue.extend({
         return this.hash === '#control-' + control.id
       })
     },
+    ...mapState({
+      // Note : we don't map sessionUserLoadStatus and controlsLoadStatus, because the only use of
+      // ControlPage is within a page which pre-fetches the data from server, so we know it is
+      // already there.
+      user: 'sessionUser',
+      controls: 'controls',
+    }),
   },
   mounted() {
     const isValidHash = (hash) => {

--- a/static/src/questionnaire-create.js
+++ b/static/src/questionnaire-create.js
@@ -3,6 +3,7 @@ import './utils/polyfills.js'
 
 import { store } from './store'
 import QuestionnaireCreate from './questionnaires/QuestionnaireCreate.vue'
+import Sidebar from './utils/SideBar.vue'
 import Vue from 'vue/dist/vue.js'
 import Vuex, { mapActions } from 'vuex'
 
@@ -17,6 +18,7 @@ new Vue({
   el: '#questionnaire-create-vm',
   components: {
     QuestionnaireCreate,
+    Sidebar,
   },
   methods: {
     ...mapActions(['fetchConfig', 'fetchControls', 'fetchSessionUser']),

--- a/static/src/questionnaire-detail.js
+++ b/static/src/questionnaire-detail.js
@@ -1,7 +1,7 @@
 import '@babel/polyfill'
 import './utils/polyfills.js'
 
-import QuestionnaireDetailPage from './questionnaires/QuestionnaireDetailPage'
+import QuestionnaireDetail from './questionnaires/QuestionnaireDetail'
 import Vue from 'vue/dist/vue.js'
 import Vuex, { mapActions } from 'vuex'
 import { store } from './store'
@@ -31,7 +31,7 @@ new Vue({
   store,
   el: '#questionnaire-detail-app',
   render: h => h(
-    QuestionnaireDetailPage,
+    QuestionnaireDetail,
     {
       props: {
         control: control,
@@ -39,10 +39,13 @@ new Vue({
       },
     }),
   methods: {
-    ...mapActions(['fetchConfig', 'fetchSessionUser']),
+    ...mapActions(['fetchConfig', 'fetchControls', 'fetchSessionUser']),
   },
   created() {
     this.fetchConfig()
     this.fetchSessionUser()
+    // TODO : we are fetching all controls for the sidebar. We could pre-fetch them from server (in
+    // the Django template)
+    this.fetchControls()
   },
 })

--- a/static/src/questionnaires/QuestionnaireDetail.vue
+++ b/static/src/questionnaires/QuestionnaireDetail.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="page-main flex-row">
+    <div id="sidebar-vm" class="border-right">
+      <sidebar></sidebar>
+    </div>
+    <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
+      <questionnaire-detail-page :control="control" :questionnaire-id="questionnaireId">
+      </questionnaire-detail-page>
+    </div>
+  </div>
+</template>
+
+<script>
+import QuestionnaireDetailPage from './QuestionnaireDetailPage'
+import Sidebar from '../utils/Sidebar'
+import Vue from 'vue'
+
+export default Vue.extend({
+  name: 'QuestionnaireDetail',
+  props: {
+    control: Object,
+    questionnaireId: Number,
+  },
+  components: {
+    QuestionnaireDetailPage,
+    Sidebar,
+  },
+})
+</script>

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -156,6 +156,11 @@ export default Vue.extend({
       this.showSidebar = false
       return
     }
+    // If the data is already there (because it was prefetched from server), build menu now.
+    // Else the watcher on isLoaded will trigger buildMenu when the data is loaded.
+    if (this.isLoaded) {
+      this.buildMenu()
+    }
   },
   methods: {
     displayError(err) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -48,23 +48,25 @@
         </div>  <!--// closing: top_header  //-->
       {% endblock page_top_row %}
 
-      <div id="page-main" class="page-main flex-row"> <!--// opening: main_page  //-->
+      {% block page_main_container_with_sidebar %}
+      <div class="page-main flex-row"> <!--// opening: main_page  //-->
 
         <div id="sidebar-vm" class="border-right">
           <sidebar></sidebar>
         </div>
+        <link href="{% static 'dist/sidebar-bundle.css' %}" rel="stylesheet" />
+        <script src="{% static 'dist/sidebar-bundle.js' %}"></script>
 
         <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
           {% block page_main_container %}
           {% endblock page_main_container %}
         </div>
       </div>  <!--// closing: main_page  //-->
+      {% endblock page_main_container_with_sidebar %}
+
     </div>
     {% include "footer.html" %}
   </div> <!--// closing: page  //-->
-
-  <link href="{% static 'dist/sidebar-bundle.css' %}" rel="stylesheet" />
-  <script src="{% static 'dist/sidebar-bundle.js' %}"></script>
 
 {% endblock content %}
 {% block session_management %}

--- a/templates/ecc/control_detail.html
+++ b/templates/ecc/control_detail.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load control_tags %}
 
-{% block page_main_container %}
+{% block page_main_container_with_sidebar %}
   <!-- No mixing of server templates + vue templates. Pass the server data outside of vue element-->
   <div id="controls-data" style="display: none">
     {{ controls_json }}
@@ -12,10 +12,10 @@
   </div>
   <!-- Vue element -->
   <div id="control-detail-vm">
-    <control-page>
-    </control-page>
+    <control-detail>
+    </control-detail>
   </div>
-{% endblock page_main_container %}
+{% endblock page_main_container_with_sidebar %}
 
 {% block js_bundle %}
 <link href="{% static 'dist/control-detail-bundle.css' %}" rel="stylesheet" />

--- a/templates/ecc/questionnaire_create.html
+++ b/templates/ecc/questionnaire_create.html
@@ -8,7 +8,6 @@
 {% block page_main_container_with_sidebar %}
   <div id="questionnaire-create-vm" class="page-main flex-row">
     <div id="sidebar-vm" class="border-right">
-      sidebar in sub template
       <sidebar></sidebar>
     </div>
 

--- a/templates/ecc/questionnaire_create.html
+++ b/templates/ecc/questionnaire_create.html
@@ -5,28 +5,35 @@
 {{ block.super }}
 {% endblock extra_static_header %}
 
-{% block page_main_container %}
+{% block page_main_container_with_sidebar %}
+  <div id="questionnaire-create-vm" class="page-main flex-row">
+    <div id="sidebar-vm" class="border-right">
+      sidebar in sub template
+      <sidebar></sidebar>
+    </div>
 
-<div id="questionnaire-create-vm">
-    {% if control is not None %}
-      <questionnaire-create
-        :control-id="{{ control.id }}"
-        :control-has-multiple-inspectors="{% if control.has_multiple_inspectors %}true{% else %}false{% endif %}"
-        :questionnaire-numbering="{{ control.next_questionnaire_numbering }}"
-      >
-      </questionnaire-create>
-    {% elif questionnaire is not None %}
-      <questionnaire-create
-        :questionnaire-id="{{ questionnaire.id }}"
-        :control-id="{{ questionnaire.control.id }}"
-        :control-has-multiple-inspectors="{% if questionnaire.control.has_multiple_inspectors %}true{% else %}false{% endif %}"
-        :questionnaire-numbering="{{ questionnaire.numbering }}"
-      >
-      </questionnaire-create>
-    {% endif %}
-</div>
-
-{% endblock page_main_container %}
+    <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
+      <div>
+        {% if control is not None %}
+          <questionnaire-create
+            :control-id="{{ control.id }}"
+            :control-has-multiple-inspectors="{% if control.has_multiple_inspectors %}true{% else %}false{% endif %}"
+            :questionnaire-numbering="{{ control.next_questionnaire_numbering }}"
+          >
+          </questionnaire-create>
+        {% elif questionnaire is not None %}
+          <questionnaire-create
+            :questionnaire-id="{{ questionnaire.id }}"
+            :control-id="{{ questionnaire.control.id }}"
+            :control-has-multiple-inspectors="{% if questionnaire.control.has_multiple_inspectors %}true{% else %}false{% endif %}"
+            :questionnaire-numbering="{{ questionnaire.numbering }}"
+          >
+          </questionnaire-create>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+{% endblock page_main_container_with_sidebar %}
 
 {% block js_bundle %}
   <link href="{% static 'dist/questionnaire-create-bundle.css' %}" rel="stylesheet" >

--- a/templates/ecc/questionnaire_detail.html
+++ b/templates/ecc/questionnaire_detail.html
@@ -13,7 +13,7 @@
   {% endif %}
 {% endblock extra_static_header %}
 
-{% block page_main_container %}
+{% block page_main_container_with_sidebar %}
   <!-- No mixing of server templates + vue templates. Pass the server data outside of vue element-->
   <div id="control-data" style="display: none">
     {{ control_json }}
@@ -23,10 +23,10 @@
   </div>
   <!-- Vue element -->
   <div id="questionnaire-detail-app">
-    <questionnaire-detail-page>
-    </questionnaire-detail-page>
+    <questionnaire-detail>
+    </questionnaire-detail>
   </div>
-{% endblock page_main_container %}
+{% endblock page_main_container_with_sidebar %}
 
 {% block js_bundle %}
   <link href="{% static 'dist/questionnaire-detail-bundle.css' %}" rel="stylesheet" />


### PR DESCRIPTION
Until now the sidebar was a completely separate bundle of js, with its own build target.

For the pages which are fully built in Vue (control-detail, questionnaire-detail, questionnaire-create), this PR uses the Sidebar.vue component inside the main js bundle, and gets rid of the separate sidebar bundle.

Note that the separate sidebar bundle is still built, for the pages like FAQ which have a Vue sidebar but no Vue in the rest of the page.

There are also changes to make the components use the Vuex store instead of passing data through props.
