### PR TITLE
Bug on "Add Control" modal in IE

### DIFF
--- a/static/src/controls/ControlCreate.vue
+++ b/static/src/controls/ControlCreate.vue
@@ -1,13 +1,11 @@
 <template>
   <div>
-    <button class="btn btn-primary"
-            data-toggle="modal"
-            data-target="#controlcreate">
+    <button class="btn btn-primary" @click="showModal">
       <i class="fe fe-plus"></i>
       Ajouter un espace de dépôt
     </button>
 
-    <confirm-modal-with-wait id="controlcreate"
+    <confirm-modal-with-wait ref="modal"
                              cancel-button="Annuler"
                              confirm-button="Créer l'espace de dépôt"
                              title="Créer un nouvel espace de dépôt"
@@ -120,6 +118,9 @@ export default Vue.extend({
     InfoBar,
   },
   methods: {
+    showModal() {
+      $(this.$refs.modal.$el).modal('show')
+    },
     createControl: function(processingDoneCallback) {
       const payload = {
         title: this.title,

--- a/static/src/utils/Sidebar.vue
+++ b/static/src/utils/Sidebar.vue
@@ -300,6 +300,9 @@ export default Vue.extend({
   /* Don't show elements sticking out of the sidebar */
   .sidebar-body {
     overflow: hidden;
+    /* Fix for IE : use inherit instead of unset, because IE doesn't know unset. This was breaking
+    the modals placed inside the sidebar. */
+    z-index: inherit;
   }
 
   /* Add borders to items */


### PR DESCRIPTION
Fix for bug in IE introduced in 1.16, where the modal for adding a new control appeared greyed out.

(not sure yet in which branch we will merge this, so don't merge for now)
Edit : merge into develop, it will go in 1.18