### PR TITLE
Update jquery to fix questionbox dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8921,9 +8921,9 @@
       }
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-beautify": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "axios": "^0.19.1",
     "bootstrap": "^4.4.1",
     "dropzone": "^5.7.0",
-    "jquery": "^3.5.0",
+    "jquery": "^3.5.1",
     "moment": "^2.24.0",
     "report-validity": "^1.0.1",
     "store": "^2.0.12",

--- a/templates/base_tabler.html
+++ b/templates/base_tabler.html
@@ -40,8 +40,8 @@
             Tabler needs bootstrap.
             Bootstrap needs jquery (and also popper, included in bootstrap.bundle.min.js).-->
           <!-- NPM dependencies linked from node_modules, see STATICFILES_DIRS in settings.py -->
-          <script src="{% static 'jquery.slim.min.js' %}"></script>
-          <script src="{% static 'bootstrap.bundle.min.js' %}"></script>
+          <script src="{% static 'jquery.slim.js' %}"></script>
+          <script src="{% static 'bootstrap.bundle.js' %}"></script>
           <script src="{% static 'tabler/core.js' %}"></script>
         {% endblock js_in_script_tags %}
         {% block js_bundle %}{% endblock js_bundle %}


### PR DESCRIPTION
Upgrade jquery to 3.5.1, to fix a compatibility problem with boostrap, that appeared in jquery 3.5.0

The questionboxes did not open any more when they were clicked (multiple browsers)