### PR TITLE
Bugfix : lowercase email when adding user

### DIFF
--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -154,6 +154,7 @@ export default Vue.extend({
     addUser() {
       this.formData.control = this.editingControl.id
       this.formData.profile_type = this.editingProfileType
+      this.formData.email = this.formData.email.toLowerCase()
       axios.post(backend.user(), this.formData)
         .then(response => {
           this.postResult = response.data
@@ -166,6 +167,7 @@ export default Vue.extend({
         })
     },
     findUser() {
+      this.formData.email = this.formData.email.toLowerCase()
       axios.get(backend.user(), {
         params: {
           search: this.formData.email,

--- a/tests/data/test.sh
+++ b/tests/data/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo Hello World

--- a/user_profiles/serializers.py
+++ b/user_profiles/serializers.py
@@ -37,8 +37,16 @@ class UserProfileSerializer(serializers.ModelSerializer):
         profile_data = validated_data
         control = profile_data.pop('control', None)
         user_data = profile_data.pop('user')
-        user_data['username'] = user_data['email']
-        profile = UserProfile.objects.filter(user__username=user_data.get('email')).first()
+
+        # lowercase the email
+        email = user_data.get('email')
+        if email:
+            email = email.lower()
+        user_data['username'] = email
+
+        # Find if user already exists.
+        profile = UserProfile.objects.filter(user__username=email).first()
+
         session_user = self.context['request'].user
         if control and control not in session_user.profile.controls.active():
             raise serializers.ValidationError(


### PR DESCRIPTION
Was causing a bug, where if you tried to add a user that already exists but with different casing for the email, the server crashed.

Fixed the frontend so that it lowercases emails and doesn't cause the bug, and also the backend to avoid seeing the bug in API. 