### PR TITLE
Bugfix for 1.18 : video player broken

### DIFF
--- a/static/src/controls/WebdavTip.vue
+++ b/static/src/controls/WebdavTip.vue
@@ -83,6 +83,7 @@
       </div>
     </empty-modal>
     <video-modal
+      v-if="canDisplayVideoPlayer"
       :id="'file-explorer-video-modal-' + controlId"
       :video-versions="[
         {
@@ -102,6 +103,7 @@
 <script>
 import { mapFields } from 'vuex-map-fields'
 import EmptyModal from '../utils/EmptyModal'
+import { loadStatuses } from '../store'
 import VideoModal from '../utils/VideoModal'
 import Vue from 'vue'
 import Vuex from 'vuex'
@@ -129,22 +131,22 @@ export default Vue.extend({
     }
   },
   computed: {
-    // Note : we don't deal with the case where config has not been fetched yet. It doesn't cause
-    // any problems for now.
-    ...mapFields(['config']),
+    ...mapFields([
+      'config',
+      'configLoadStatus',
+    ]),
+    // Wait for the config to load (so that we have the video urls) before displaying the video
+    // player. Otherwise it breaks on some browsers and machines.
+    canDisplayVideoPlayer() {
+      return this.configLoadStatus === loadStatuses.SUCCESS
+    },
     webdavurl: function() {
       return this.config.webdav_url + '/' + this.referenceCode
     },
     videoUrlMp4() {
-      if (typeof this.config.static_files_url === 'undefined') {
-        return ''
-      }
       return this.config.static_files_url + VIDEO_FILE_PATH_MP4
     },
     videoUrlWebm() {
-      if (typeof this.config.static_files_url === 'undefined') {
-        return ''
-      }
       return this.config.static_files_url + VIDEO_FILE_PATH_WEBM
     },
   },

--- a/static/src/store.js
+++ b/static/src/store.js
@@ -15,6 +15,7 @@ export const loadStatuses = {
 export const store = new Vuex.Store({
   state: {
     config: {},
+    configLoadStatus: loadStatuses.LOADING,
     controls: [],
     controlsLoadStatus: loadStatuses.LOADING,
     currentQuestionnaire: {},
@@ -38,6 +39,9 @@ export const store = new Vuex.Store({
     updateConfig(state, config) {
       state.config = config
     },
+    updateConfigLoadStatus(state, newStatus) {
+      state.configLoadStatus = newStatus
+    },
     updateControls(state, controls) {
       state.controls = controls
     },
@@ -50,6 +54,10 @@ export const store = new Vuex.Store({
       axios.get(backendUrls.config()).then((response) => {
         console.debug('Store got config', response.data)
         commit('updateConfig', response.data)
+        commit('updateConfigLoadStatus', loadStatuses.SUCCESS)
+      }).catch(err => {
+        console.error('Store got error fetching config', err)
+        commit('updateConfigLoadStatus', loadStatuses.ERROR)
       })
     },
     fetchSessionUser({ commit }) {


### PR DESCRIPTION
Wait for the config to be fetched (so that the video url is filled in) before we display the videoplayer. 