### PR TITLE
Add setting to use console email backend for development

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,11 @@ export CELERY_BROKER_URL=redis://localhost:6379
 #export STATIC_ROOT=/var/ecc/static
 
 # Email Debug
+# For production, do not set EMAIL_BACKEND.
+# For development, you can use console backend to print emails to console instead of sending them.
+# (File backend could also be used, see https://docs.djangoproject.com/en/3.0/topics/email/#email-backends)
+export EMAIL_BACKEND='django.core.mail.backends.console.EmailBackend'
+# Config for debugmail
 export EMAIL_HOST=debugmail.io
 export EMAIL_PORT=25
 export EMAIL_HOST_USER=TODO

--- a/ecc/settings.py
+++ b/ecc/settings.py
@@ -186,6 +186,7 @@ if DEBUG:
     SESSION_COOKIE_SECURE = False
 
 # Email
+EMAIL_BACKEND = env('EMAIL_BACKEND', default='django.core.mail.backends.smtp.EmailBackend')
 EMAIL_HOST = env('EMAIL_HOST')
 EMAIL_PORT = env('EMAIL_PORT')
 EMAIL_HOST_USER = env('EMAIL_HOST_USER',)


### PR DESCRIPTION
Not tested on DEV. We want to be sure not to break the prod machines...