### PR TITLE
Remove dot after url in email

### DIFF
--- a/templates/user_profiles/email_add_user.html
+++ b/templates/user_profiles/email_add_user.html
@@ -17,7 +17,9 @@
 <p class="text-justify">
 Bonjour {{ target_user.first_name }} {{ target_user.last_name }},
 <br/>
-Dans le cadre de la procédure "{{ control.title_display }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur https://{{ site.domain }}.
+Dans le cadre de la procédure "{{ control.title_display }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur :
+<br/>
+https://{{ site.domain }}
 <br/>
 Cordialement,
 </p>

--- a/templates/user_profiles/email_add_user.txt
+++ b/templates/user_profiles/email_add_user.txt
@@ -13,7 +13,10 @@ Voici un message type:
 
 * * *
 Bonjour {{ target_user.first_name }} {{ target_user.last_name }},
-Dans le cadre de la procédure "{{ control.title_display }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur https://{{ site.domain }}.
+Dans le cadre de la procédure "{{ control.title_display }}", vous pouvez accéder à l’espace de dépôt en vous connectant sur :
+
+https://{{ site.domain }}
+
 Cordialement,
 * * *
 


### PR DESCRIPTION
Remove dot after url in email and move it to new line, for easy copy-pasting. We had someone who was copy-pasting with the dot, and could not log in.