### PR TITLE
Temp fix : Update magicauth email message to specify token duration, hard-coded

### DIFF
--- a/templates/login/email.html
+++ b/templates/login/email.html
@@ -19,6 +19,7 @@
     </tr>
   </tbody>
 </table>
+<div>Ce lien n'est valable que 5 minutes. Il est à usage unique.</div>
 <hr class="text-muted">
 <div class="text-muted-dark">
   <p>Des difficultés pour vous connecter ?</p>

--- a/templates/login/email.txt
+++ b/templates/login/email.txt
@@ -8,6 +8,8 @@ Des difficultés pour vous connecter ?
 Nous vous recommandons de copier-coller ce lien dans Mozilla Firefox ou Chrome :
 https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}
 
+Ce lien n'est valable que 5 minutes. Il est à usage unique.
+
 Si vous rencontrez toujours des difficultés pour vous connecter, répondez directement à cet email.
 
 Merci beaucoup,


### PR DESCRIPTION
Because this is causing problems for users, add explanations in the magicauth email that the link is single-use and expires after 5min.

For now, the value (5min) is hard-coded. This PR will make it not-hard-coded, once we have updated magicauth : https://github.com/betagouv/e-controle/pull/578