### PR TITLE
Fix style for wait page

### DIFF
--- a/ecc/settings.py
+++ b/ecc/settings.py
@@ -212,6 +212,7 @@ MAGICAUTH_EMAIL_HTML_TEMPLATE = 'login/email.html'
 MAGICAUTH_EMAIL_TEXT_TEMPLATE = 'login/email.txt'
 MAGICAUTH_LOGIN_VIEW_TEMPLATE = 'login/login.html'
 MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE = 'login/email_sent.html'
+MAGICAUTH_WAIT_VIEW_TEMPLATE = 'login/wait.html'
 
 LOGIN_URL = 'login'
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -32,19 +32,21 @@
             </div>   <!--// closing: nav_items  //-->
           {% endblock nav_items %}
 
-          <div class="dropdown p-3"> <!--// opening: main_profile_dropdown  //-->
-            <a href="#" class="nav-link" data-toggle="dropdown">
-              <span class="avatar avatar-pink">{{ user.first_name|first }}{{ user.last_name|first }}</span>
-              <span class="ml-2 text-default">
-                {{ user.get_full_name }}
-              </span>
-            </a>
-            <div class="dropdown-menu dropdown-menu-right dropdown-menu-arrow">
-              <a class="dropdown-item" href="{% url 'logout' %}">
-                <i class="dropdown-icon fe fe-log-out"></i> Se déconnecter
+          {% block current_user %}
+            <div class="dropdown p-3">
+              <a href="#" class="nav-link" data-toggle="dropdown">
+                <span class="avatar avatar-pink">{{ user.first_name|first }}{{ user.last_name|first }}</span>
+                <span class="ml-2 text-default">
+                  {{ user.get_full_name }}
+                </span>
               </a>
+              <div class="dropdown-menu dropdown-menu-right dropdown-menu-arrow">
+                <a class="dropdown-item" href="{% url 'logout' %}">
+                  <i class="dropdown-icon fe fe-log-out"></i> Se déconnecter
+                </a>
+              </div>
             </div>
-          </div> <!--// closing: main_profile_dropdown  //-->
+          {% endblock current_user %}
         </div>  <!--// closing: top_header  //-->
       {% endblock page_top_row %}
 
@@ -65,7 +67,9 @@
       {% endblock page_main_container_with_sidebar %}
 
     </div>
-    {% include "footer.html" %}
+    {% block footer %}
+      {% include "footer.html" %}
+    {% endblock footer %}
   </div> <!--// closing: page  //-->
 
 {% endblock content %}

--- a/templates/login/wait.html
+++ b/templates/login/wait.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% load static %}
+
+{% block nav_items %}
+{% endblock nav_items %}
+
+{% block current_user %}
+<!-- No current user, so add a placeholder to maintain the topbar height. -->
+<div style="min-height: 56px;"></div>
+{% endblock current_user %}
+
+{% block page_main_container_with_sidebar %}
+  <script>
+    var url = '{{ next_step_url }}'
+    var waitSeconds = {{ WAIT_SECONDS }}
+
+    console.debug('Redirecting to', url, 'in', waitSeconds, 'seconds')
+    setTimeout(function(){
+      window.location.replace(url);
+    }, waitSeconds * 1000);
+
+  </script>
+  <div class="page">
+    <div class="mt-9 flex-column justify-content-center align-items-center">
+      <div class="card col-login">
+        <div class="card-body flex-column align-items-center bg-info text-white">
+          <h1>En chargement...</h1>
+          <div class="mb-6">Veuillez patienter quelques instants</div>
+          <div class="loader"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock page_main_container_with_sidebar %}
+
+{% block footer %}
+{% endblock footer %}

--- a/templates/login/wait.html
+++ b/templates/login/wait.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block nav_items %}
+<!-- No nav items because not logged it yet. -->
 {% endblock nav_items %}
 
 {% block current_user %}
@@ -34,4 +35,5 @@
 {% endblock page_main_container_with_sidebar %}
 
 {% block footer %}
+<!-- No footer because not logged it yet (footer contains links). -->
 {% endblock footer %}


### PR DESCRIPTION
The default magicauth wait page uses an external stylesheet (from https://tabler.github.io) which is blocked by our CSP. So style is broken.

This PR overrides the default template provided by magicauth, to use our own, with the stylesheet served from our own server.