### PR TITLE
TOS page without login

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,31 +21,41 @@
           </div>
 
           {% block nav_items %}
-            <div class="nav nav-tabs border-0 flex-row flex-grow-1 justify-content-end"> <!--// opening: nav_items  //-->
-              <div class="nav-item">
-                {% url 'faq' as faq_url %}
-                <a class="nav-link nav-link-thick-line {% if request.path == faq_url %}active{% endif %}"
-                  href="{% url 'faq'%}">
-                  <i class="fe fe-help-circle"></i> FAQ
-                </a>
+            {% if user.is_authenticated %}
+              <div class="nav nav-tabs border-0 flex-row flex-grow-1 justify-content-end"> <!--// opening: nav_items  //-->
+                <div class="nav-item">
+                  {% url 'faq' as faq_url %}
+                  <a class="nav-link nav-link-thick-line {% if request.path == faq_url %}active{% endif %}"
+                    href="{% url 'faq'%}">
+                    <i class="fe fe-help-circle"></i> FAQ
+                  </a>
+                </div>
               </div>
-            </div>   <!--// closing: nav_items  //-->
+            {% else %}
+              <!-- add a placeholder to maintain the topbar height. -->
+              <div style="min-height: 56px;"></div>
+            {% endif %}
           {% endblock nav_items %}
 
           {% block current_user %}
-            <div class="dropdown p-3">
-              <a href="#" class="nav-link" data-toggle="dropdown">
-                <span class="avatar avatar-pink">{{ user.first_name|first }}{{ user.last_name|first }}</span>
-                <span class="ml-2 text-default">
-                  {{ user.get_full_name }}
-                </span>
-              </a>
-              <div class="dropdown-menu dropdown-menu-right dropdown-menu-arrow">
-                <a class="dropdown-item" href="{% url 'logout' %}">
-                  <i class="dropdown-icon fe fe-log-out"></i> Se déconnecter
+            {% if user.is_authenticated %}
+              <div class="dropdown p-3">
+                <a href="#" class="nav-link" data-toggle="dropdown">
+                  <span class="avatar avatar-pink">{{ user.first_name|first }}{{ user.last_name|first }}</span>
+                  <span class="ml-2 text-default">
+                    {{ user.get_full_name }}
+                  </span>
                 </a>
+                <div class="dropdown-menu dropdown-menu-right dropdown-menu-arrow">
+                  <a class="dropdown-item" href="{% url 'logout' %}">
+                    <i class="dropdown-icon fe fe-log-out"></i> Se déconnecter
+                  </a>
+                </div>
               </div>
-            </div>
+            {% else %}
+              <!-- add a placeholder to maintain the topbar height. -->
+              <div style="min-height: 56px;"></div>
+            {% endif %}
           {% endblock current_user %}
         </div>  <!--// closing: top_header  //-->
       {% endblock page_top_row %}

--- a/templates/login/wait.html
+++ b/templates/login/wait.html
@@ -1,15 +1,6 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block nav_items %}
-<!-- No nav items because not logged it yet. -->
-{% endblock nav_items %}
-
-{% block current_user %}
-<!-- No current user, so add a placeholder to maintain the topbar height. -->
-<div style="min-height: 56px;"></div>
-{% endblock current_user %}
-
 {% block page_main_container_with_sidebar %}
   <script>
     var url = '{{ next_step_url }}'
@@ -33,7 +24,3 @@
     </div>
   </div>
 {% endblock page_main_container_with_sidebar %}
-
-{% block footer %}
-<!-- No footer because not logged it yet (footer contains links). -->
-{% endblock footer %}

--- a/tos/templates/tos/tos.html
+++ b/tos/templates/tos/tos.html
@@ -3,232 +3,232 @@
 {% load email_obfuscator %}
 
 {% block page_main_container_with_sidebar %}
-<div class="page-main flex-row">
-  {% if user.is_authenticated %}
-    <div id="sidebar-vm" class="border-right">
-      <sidebar></sidebar>
-    </div>
-    <link href="{% static 'dist/sidebar-bundle.css' %}" rel="stylesheet" />
-    <script src="{% static 'dist/sidebar-bundle.js' %}"></script>
-  {% endif %}
-
-  <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
-    <div class="container">
-
-      <div class="page-header">
-        <h1 class="page-title">
-          {% block page_title %}
-            Conditions générales d'utilisation
-          {% endblock page_title %}
-        </h1>
+  <div class="page-main flex-row">
+    {% if user.is_authenticated %}
+      <div id="sidebar-vm" class="border-right">
+        <sidebar></sidebar>
       </div>
+      <link href="{% static 'dist/sidebar-bundle.css' %}" rel="stylesheet" />
+      <script src="{% static 'dist/sidebar-bundle.js' %}"></script>
+    {% endif %}
 
-      <div class="alert alert-primary mb-0">
-        <p class="h4">
-          En utilisant l’application e.contrôle, vous vous engagez à respecter les conditions générales d'utilisation suivantes :
-        </p>
-      </div>
+    <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
+      <div class="container">
 
-
-      <div class="text-justify mt-6">
-        {% block subtitle %}
-        {% endblock subtitle %}
-        <div class="scrollbox">
-          <div>
-            <h4>1. Préambule</h4>
-            <p>
-              La Cour des comptes et les Chambres régionales et territoriales des comptes
-              sont habilitées à accéder à tous documents, données et traitements, de quelque
-              nature que ce soit, relatifs à la gestion des services et organismes soumis à leurs
-              contrôles ou nécessaires à l'exercice de leurs attributions, et à se les faire
-              communiquer.
-            </p>
-            <p>
-              Le fait de faire obstacle, de quelque façon que ce soit, à l'exercice des pouvoirs
-              attribués aux membres et personnels de la Cour des comptes, et des Chambres
-              régionales et territoriales des comptes, est puni de 15 000 euros d'amende
-              conformément au code des juridictions financières. Le procureur général près la
-              Cour des comptes peut saisir le parquet près la juridiction compétente en vue de
-              déclencher l'action publique.
-            </p>
-          </div>
-
-          <div>
-            <h4>2. Caractéristiques techniques</h4>
-            <p>
-              La liaison avec l’application e.contrôle s'effectue au moyen d'un protocole sécurisé
-              depuis le site
-              <a href="https://e-controles-beta.ccomptes.fr/" target="_blank" rel="noopener noreferrer">
-                https://e-controles-beta.ccomptes.fr/
-              </a>
-            </p>
-            <p>
-              L’utilisation d’un navigateur Internet usuel dans une version maintenue par l’éditeur
-              est recommandée pour une utilisation optimale de l’application e.contrôle. L’utilisation
-              de l’application requiert en outre un logiciel permettant la lecture des documents au
-              format PDF (Portable Document Format), DOCX (documentation en format texte) et
-              XLSX (document en format tableau).
-            </p>
-            <p>
-              Les navigateurs utilisés doivent activer JavaScript et accepter les cookies.
-            </p>
-            <p>
-              Chaque utilisateur doit disposer d’une adresse électronique active qui sera liée à son
-              compte personnel. Chaque utilisateur doit s’assurer de conserver cette adresse
-              électronique en fonctionnement. Il peut, le cas échéant, demander son remplacement en
-              sollicitant l’équipe de contrôle.
-            </p>
-          </div>
-
-          <div>
-            <h4>3. Identification et sécurité</h4>
-            <p><strong>Identifiant</strong></p>
-            <p>
-              Les agents des juridictions financières sont automatiquement reconnus et authentifiés de
-              manière sécurisée par l'application e.contrôle comme étant des membres internes des
-              juridictions financières.
-            </p>
-            <p>
-              Les agents des organismes interrogés peuvent se connecter à l'application e.contrôle en
-              sollicitant un compte auprès de l'équipe de contrôle.
-            </p>
-            <p>
-              Lors de la création d’un compte e.contrôle, l’identifiant est une adresse électronique.
-            </p>
-            <p>
-              La connexion ne nécessite pas de mot de passe. Elle est réalisée par l’envoi d’un email
-              contenant un lien de connexion unique, temporaire et dont la durée de validité est
-              limitée dans le temps.
-            </p>
-            <p><strong>Traçage et cookies</strong></p>
-            <p>
-              L’application e.contrôle utilise un cookie (témoin de navigation) sur le navigateur du
-              client pour stocker un identifiant de session. Ce cookie ne contient aucune autre
-              information et est rendu invalide à la fin de la session de navigation.
-            </p>
-          </div>
-
-          <div>
-            <h4>4. Transfert de documents</h4>
-            <p>Seuls les fichiers en rapport avec les procédures des juridictions financières doivent
-              être chargés dans l’application e.contrôle. Ces fichiers doivent uniquement avoir un
-              contenu qui n'évolue pas (conenu statique) et être non protégés. La taille maximale de chaque fichier est fixée à
-              256 Mo. Les utilisateurs doivent privilégier les formats PDF, DOCX, DOC, ODT (documents texte), XLSX, XLS, ODS (documents tableur), CSV, ZIP, JPG,
-              PNG et JPG (documents image).
-            </p>
-            <p>
-              Il appartient à l’utilisateur de contrôler l’exactitude du contenu et de la forme des
-              fichiers déposés. L’utilisateur ne pourra ni modifier ni supprimer définitivement les
-              documents déposés. La qualité et la capacité du réseau à la disposition de l’utilisateur
-              peuvent affecter la vitesse de transmission des documents.
-            </p>
-          </div>
-
-          <div>
-            <h4>5. Aide et précaution</h4>
-            <p>
-              En cas de problèmes rencontrés dans l’utilisation de l’application, les utilisateurs
-              peuvent contacter
-              {{ settings.SUPPORT_TEAM_EMAIL|obfuscate_mailto:"la plate-forme d’assistance" }}
-            </p>
-            <p>
-              En cas d’indisponibilité temporaire du service e.contrôle, l’utilisateur peut, s’il est
-              contraint par un délai, transmettre ses documents aux équipe de contrôle par voie papier,
-              par télécopie ou par message électronique adressé à l’adresse de l’équipe de contrôle.
-            </p>
-            <p>
-              Il appartient par ailleurs à l’utilisateur de s’assurer du bon fonctionnement de son
-              matériel et de son réseau. L’utilisateur doit être conscient des limites de sécurité de
-              son poste de travail. Il peut se référer aux bonnes pratiques présentées sur le
-              site
-              <a href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
-                target="_blank"
-                rel="noopener noreferrer">
-                http://www.ssi.gouv.fr/administration/bonnes-pratiques/
-              </a>
-              .
-            </p>
-          </div>
-
-
-          <div>
-            <h4>6. Données personnelles</h4>
-            <p>
-              L’application e.contrôle est mise en œuvre par la direction des systèmes d’information
-              de la Cour des comptes.
-            </p>
-            <p>
-              Les données recueillies par cette application le sont pour permettre la gestion de
-              l’activité de contrôle des juridictions financières conformément aux dispositions
-              prévues par le code des juridictions financières. Elles sont protégées par le secret de
-              l’instruction. Les juridictions financières s’engagent à prendre toute disposition pour garantir le secret de leurs investigations et la
-              protection des informations transmises. Pour tout renseignement et pour exercer vos
-              droits, vous pouvez prendre contact auprès de la déléguée à la protection des
-              données (DPO) des juridictions financières à l’adresse suivante : dpo-jf[at]ccomptes.fr
-              ou par courrier : Cour des comptes, 13 rue Cambon, 75001 Paris.
-            </p>
-          </div>
-
-          <div>
-            <h4>7. Evolution du service</h4>
-            <p>
-              Nous pouvons faire évoluer e.contrôle sans information préalable ou préavis.
-              Nous ajoutons et améliorons régulièrement l’interface et modifions les formulations sur la base de vos retours, des évolutions réglementaires et législatives, et des mises à jour de sécurité.
-            </p>
-          </div>
-
-          <div>
-            <h4>8. Disponilité du service</h4>
-            <p>
-              Nous pouvons suspendre l’accès à e.contrôle sans information préalable ni préavis,
-              notamment pour des raisons de maintenance. Nous mettons e.contrôle à disposition sans
-              garantie sur sa disponibilité. Même si nous nous efforçons de maintenir le service toujours opérationnel,
-              cela signifie que d’éventuelles indisponibilités n’ouvriront pas droit à compensation financière.
-              Nous nous réservons également le droit de bloquer, sans information préalable ni compensation financière,
-              les usages mettant en péril l’utilisation du logiciel par d’autres usagers. Cela nous permet d’anticiper
-              d’éventuelles attaques par déni de service.
-            </p>
-          </div>
-
-          <div>
-            <h4>9. Evolution des conditions d'utilisation</h4>
-            <p>
-              Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
-              en fonction des modifications apportées au service, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
-              Ces modifications et mises à jour s’imposent à l’utilisateur qui doit, en conséquence, se référer régulièrement à cette rubrique
-              pour vérifier les conditions générales en vigueur.
-            </p>
-          </div>
-
-          <div>
-            <h4>10.Références</h4>
-            <ul>
-              <li>
-                <a href="https://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006070249">
-                  Code des juridictions financières et notamment ses articles L141-2 et suivants.
-                </a>
-              </li>
-              <li>
-                <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037085952&categorieLien=id">
-                  Loi n° 2018-493 du 20 juin 2018 relative à la protection des données personnelles
-                </a>
-              </li>
-              <li>
-                <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037800506&categorieLien=id">
-                  Ordonnance n° 2018-1125 du 12 décembre 2018 prise en application de l'article 32 de la loi n° 2018-493
-                  du 20 juin 2018 relative à la protection des données personnelles et portant modification de la
-                  loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés et diverses
-                  dispositions concernant la protection des données à caractère personnel et notamment son article 52.
-                </a>
-              </li>
-            </ul>
-          </div>
+        <div class="page-header">
+          <h1 class="page-title">
+            {% block page_title %}
+              Conditions générales d'utilisation
+            {% endblock page_title %}
+          </h1>
         </div>
-        {% block approval %}
-        {% endblock approval %}
-      </div>
-    </div>
 
+        <div class="alert alert-primary mb-0">
+          <p class="h4">
+            En utilisant l’application e.contrôle, vous vous engagez à respecter les conditions générales d'utilisation suivantes :
+          </p>
+        </div>
+
+
+        <div class="text-justify mt-6">
+          {% block subtitle %}
+          {% endblock subtitle %}
+          <div class="scrollbox">
+            <div>
+              <h4>1. Préambule</h4>
+              <p>
+                La Cour des comptes et les Chambres régionales et territoriales des comptes
+                sont habilitées à accéder à tous documents, données et traitements, de quelque
+                nature que ce soit, relatifs à la gestion des services et organismes soumis à leurs
+                contrôles ou nécessaires à l'exercice de leurs attributions, et à se les faire
+                communiquer.
+              </p>
+              <p>
+                Le fait de faire obstacle, de quelque façon que ce soit, à l'exercice des pouvoirs
+                attribués aux membres et personnels de la Cour des comptes, et des Chambres
+                régionales et territoriales des comptes, est puni de 15 000 euros d'amende
+                conformément au code des juridictions financières. Le procureur général près la
+                Cour des comptes peut saisir le parquet près la juridiction compétente en vue de
+                déclencher l'action publique.
+              </p>
+            </div>
+
+            <div>
+              <h4>2. Caractéristiques techniques</h4>
+              <p>
+                La liaison avec l’application e.contrôle s'effectue au moyen d'un protocole sécurisé
+                depuis le site
+                <a href="https://e-controles-beta.ccomptes.fr/" target="_blank" rel="noopener noreferrer">
+                  https://e-controles-beta.ccomptes.fr/
+                </a>
+              </p>
+              <p>
+                L’utilisation d’un navigateur Internet usuel dans une version maintenue par l’éditeur
+                est recommandée pour une utilisation optimale de l’application e.contrôle. L’utilisation
+                de l’application requiert en outre un logiciel permettant la lecture des documents au
+                format PDF (Portable Document Format), DOCX (documentation en format texte) et
+                XLSX (document en format tableau).
+              </p>
+              <p>
+                Les navigateurs utilisés doivent activer JavaScript et accepter les cookies.
+              </p>
+              <p>
+                Chaque utilisateur doit disposer d’une adresse électronique active qui sera liée à son
+                compte personnel. Chaque utilisateur doit s’assurer de conserver cette adresse
+                électronique en fonctionnement. Il peut, le cas échéant, demander son remplacement en
+                sollicitant l’équipe de contrôle.
+              </p>
+            </div>
+
+            <div>
+              <h4>3. Identification et sécurité</h4>
+              <p><strong>Identifiant</strong></p>
+              <p>
+                Les agents des juridictions financières sont automatiquement reconnus et authentifiés de
+                manière sécurisée par l'application e.contrôle comme étant des membres internes des
+                juridictions financières.
+              </p>
+              <p>
+                Les agents des organismes interrogés peuvent se connecter à l'application e.contrôle en
+                sollicitant un compte auprès de l'équipe de contrôle.
+              </p>
+              <p>
+                Lors de la création d’un compte e.contrôle, l’identifiant est une adresse électronique.
+              </p>
+              <p>
+                La connexion ne nécessite pas de mot de passe. Elle est réalisée par l’envoi d’un email
+                contenant un lien de connexion unique, temporaire et dont la durée de validité est
+                limitée dans le temps.
+              </p>
+              <p><strong>Traçage et cookies</strong></p>
+              <p>
+                L’application e.contrôle utilise un cookie (témoin de navigation) sur le navigateur du
+                client pour stocker un identifiant de session. Ce cookie ne contient aucune autre
+                information et est rendu invalide à la fin de la session de navigation.
+              </p>
+            </div>
+
+            <div>
+              <h4>4. Transfert de documents</h4>
+              <p>Seuls les fichiers en rapport avec les procédures des juridictions financières doivent
+                être chargés dans l’application e.contrôle. Ces fichiers doivent uniquement avoir un
+                contenu qui n'évolue pas (conenu statique) et être non protégés. La taille maximale de chaque fichier est fixée à
+                256 Mo. Les utilisateurs doivent privilégier les formats PDF, DOCX, DOC, ODT (documents texte), XLSX, XLS, ODS (documents tableur), CSV, ZIP, JPG,
+                PNG et JPG (documents image).
+              </p>
+              <p>
+                Il appartient à l’utilisateur de contrôler l’exactitude du contenu et de la forme des
+                fichiers déposés. L’utilisateur ne pourra ni modifier ni supprimer définitivement les
+                documents déposés. La qualité et la capacité du réseau à la disposition de l’utilisateur
+                peuvent affecter la vitesse de transmission des documents.
+              </p>
+            </div>
+
+            <div>
+              <h4>5. Aide et précaution</h4>
+              <p>
+                En cas de problèmes rencontrés dans l’utilisation de l’application, les utilisateurs
+                peuvent contacter
+                {{ settings.SUPPORT_TEAM_EMAIL|obfuscate_mailto:"la plate-forme d’assistance" }}
+              </p>
+              <p>
+                En cas d’indisponibilité temporaire du service e.contrôle, l’utilisateur peut, s’il est
+                contraint par un délai, transmettre ses documents aux équipe de contrôle par voie papier,
+                par télécopie ou par message électronique adressé à l’adresse de l’équipe de contrôle.
+              </p>
+              <p>
+                Il appartient par ailleurs à l’utilisateur de s’assurer du bon fonctionnement de son
+                matériel et de son réseau. L’utilisateur doit être conscient des limites de sécurité de
+                son poste de travail. Il peut se référer aux bonnes pratiques présentées sur le
+                site
+                <a href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
+                  target="_blank"
+                  rel="noopener noreferrer">
+                  http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+                </a>
+                .
+              </p>
+            </div>
+
+
+            <div>
+              <h4>6. Données personnelles</h4>
+              <p>
+                L’application e.contrôle est mise en œuvre par la direction des systèmes d’information
+                de la Cour des comptes.
+              </p>
+              <p>
+                Les données recueillies par cette application le sont pour permettre la gestion de
+                l’activité de contrôle des juridictions financières conformément aux dispositions
+                prévues par le code des juridictions financières. Elles sont protégées par le secret de
+                l’instruction. Les juridictions financières s’engagent à prendre toute disposition pour garantir le secret de leurs investigations et la
+                protection des informations transmises. Pour tout renseignement et pour exercer vos
+                droits, vous pouvez prendre contact auprès de la déléguée à la protection des
+                données (DPO) des juridictions financières à l’adresse suivante : dpo-jf[at]ccomptes.fr
+                ou par courrier : Cour des comptes, 13 rue Cambon, 75001 Paris.
+              </p>
+            </div>
+
+            <div>
+              <h4>7. Evolution du service</h4>
+              <p>
+                Nous pouvons faire évoluer e.contrôle sans information préalable ou préavis.
+                Nous ajoutons et améliorons régulièrement l’interface et modifions les formulations sur la base de vos retours, des évolutions réglementaires et législatives, et des mises à jour de sécurité.
+              </p>
+            </div>
+
+            <div>
+              <h4>8. Disponilité du service</h4>
+              <p>
+                Nous pouvons suspendre l’accès à e.contrôle sans information préalable ni préavis,
+                notamment pour des raisons de maintenance. Nous mettons e.contrôle à disposition sans
+                garantie sur sa disponibilité. Même si nous nous efforçons de maintenir le service toujours opérationnel,
+                cela signifie que d’éventuelles indisponibilités n’ouvriront pas droit à compensation financière.
+                Nous nous réservons également le droit de bloquer, sans information préalable ni compensation financière,
+                les usages mettant en péril l’utilisation du logiciel par d’autres usagers. Cela nous permet d’anticiper
+                d’éventuelles attaques par déni de service.
+              </p>
+            </div>
+
+            <div>
+              <h4>9. Evolution des conditions d'utilisation</h4>
+              <p>
+                Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
+                en fonction des modifications apportées au service, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
+                Ces modifications et mises à jour s’imposent à l’utilisateur qui doit, en conséquence, se référer régulièrement à cette rubrique
+                pour vérifier les conditions générales en vigueur.
+              </p>
+            </div>
+
+            <div>
+              <h4>10.Références</h4>
+              <ul>
+                <li>
+                  <a href="https://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006070249">
+                    Code des juridictions financières et notamment ses articles L141-2 et suivants.
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037085952&categorieLien=id">
+                    Loi n° 2018-493 du 20 juin 2018 relative à la protection des données personnelles
+                  </a>
+                </li>
+                <li>
+                  <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037800506&categorieLien=id">
+                    Ordonnance n° 2018-1125 du 12 décembre 2018 prise en application de l'article 32 de la loi n° 2018-493
+                    du 20 juin 2018 relative à la protection des données personnelles et portant modification de la
+                    loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés et diverses
+                    dispositions concernant la protection des données à caractère personnel et notamment son article 52.
+                  </a>
+                </li>
+              </ul>
+            </div>
+          </div>
+          {% block approval %}
+          {% endblock approval %}
+        </div>
+      </div>
+
+    </div>
   </div>
-</div>
 {% endblock page_main_container_with_sidebar %}

--- a/tos/templates/tos/tos.html
+++ b/tos/templates/tos/tos.html
@@ -1,215 +1,234 @@
 {% extends "base.html" %}
+{% load static %}
 {% load email_obfuscator %}
 
-{% block page_main_container %}
-<div class="container">
+{% block page_main_container_with_sidebar %}
+<div class="page-main flex-row">
+  {% if user.is_authenticated %}
+    <div id="sidebar-vm" class="border-right">
+      <sidebar></sidebar>
+    </div>
+    <link href="{% static 'dist/sidebar-bundle.css' %}" rel="stylesheet" />
+    <script src="{% static 'dist/sidebar-bundle.js' %}"></script>
+  {% endif %}
 
-  <div class="page-header">
-    <h1 class="page-title">
-      {% block page_title %}
-        Conditions générales d'utilisation
-      {% endblock page_title %}
-    </h1>
-  </div>
+  <div class="mt-3 mt-md-5 flex-grow-1 ml-6 ie-flex-row-child">
+    <div class="container">
 
-  <div class="alert alert-primary mb-0">
-    <p class="h4">
-      En utilisant l’application e.contrôle, vous vous engagez à respecter les conditions générales d'utilisation suivantes :
-    </p>
-  </div>
-
-
-  <div class="text-justify mt-6">
-    {% block subtitle %}
-    {% endblock subtitle %}
-    <div class="scrollbox">
-      <div>
-        <h4>1. Préambule</h4>
-        <p>
-          La Cour des comptes et les Chambres régionales et territoriales des comptes
-          sont habilitées à accéder à tous documents, données et traitements, de quelque
-          nature que ce soit, relatifs à la gestion des services et organismes soumis à leurs
-          contrôles ou nécessaires à l'exercice de leurs attributions, et à se les faire
-          communiquer.
-        </p>
-        <p>
-          Le fait de faire obstacle, de quelque façon que ce soit, à l'exercice des pouvoirs
-          attribués aux membres et personnels de la Cour des comptes, et des Chambres
-          régionales et territoriales des comptes, est puni de 15 000 euros d'amende
-          conformément au code des juridictions financières. Le procureur général près la
-          Cour des comptes peut saisir le parquet près la juridiction compétente en vue de
-          déclencher l'action publique.
-        </p>
+      <div class="page-header">
+        <h1 class="page-title">
+          {% block page_title %}
+            Conditions générales d'utilisation
+          {% endblock page_title %}
+        </h1>
       </div>
 
-      <div>
-        <h4>2. Caractéristiques techniques</h4>
-        <p>
-          La liaison avec l’application e.contrôle s'effectue au moyen d'un protocole sécurisé
-          depuis le site
-          <a href="https://e-controles-beta.ccomptes.fr/" target="_blank" rel="noopener noreferrer">
-            https://e-controles-beta.ccomptes.fr/
-          </a>
-        </p>
-        <p>
-          L’utilisation d’un navigateur Internet usuel dans une version maintenue par l’éditeur
-          est recommandée pour une utilisation optimale de l’application e.contrôle. L’utilisation
-          de l’application requiert en outre un logiciel permettant la lecture des documents au
-          format PDF (Portable Document Format), DOCX (documentation en format texte) et
-          XLSX (document en format tableau).
-        <p>
-          Les navigateurs utilisés doivent activer JavaScript et accepter les cookies.
-        </p>
-        <p>
-          Chaque utilisateur doit disposer d’une adresse électronique active qui sera liée à son
-          compte personnel. Chaque utilisateur doit s’assurer de conserver cette adresse
-          électronique en fonctionnement. Il peut, le cas échéant, demander son remplacement en
-          sollicitant l’équipe de contrôle.
-        </p>
-      </div>
-
-      <div>
-        <h4>3. Identification et sécurité</h4>
-        <p><strong>Identifiant</strong></p>
-        <p>
-          Les agents des juridictions financières sont automatiquement reconnus et authentifiés de
-          manière sécurisée par l'application e.contrôle comme étant des membres internes des
-          juridictions financières.
-        </p>
-        <p>
-          Les agents des organismes interrogés peuvent se connecter à l'application e.contrôle en
-          sollicitant un compte auprès de l'équipe de contrôle.
-        <p>
-          Lors de la création d’un compte e.contrôle, l’identifiant est une adresse électronique.
-        </p>
-        <p>
-          La connexion ne nécessite pas de mot de passe. Elle est réalisée par l’envoi d’un email
-          contenant un lien de connexion unique, temporaire et dont la durée de validité est
-          limitée dans le temps.
-        <p><strong>Traçage et cookies</strong></p>
-        <p>
-          L’application e.contrôle utilise un cookie (témoin de navigation) sur le navigateur du
-          client pour stocker un identifiant de session. Ce cookie ne contient aucune autre
-          information et est rendu invalide à la fin de la session de navigation.
-        </p>
-      </div>
-
-      <div>
-        <h4>4. Transfert de documents</h4>
-        <p>Seuls les fichiers en rapport avec les procédures des juridictions financières doivent
-          être chargés dans l’application e.contrôle. Ces fichiers doivent uniquement avoir un
-          contenu qui n'évolue pas (conenu statique) et être non protégés. La taille maximale de chaque fichier est fixée à
-          256 Mo. Les utilisateurs doivent privilégier les formats PDF, DOCX, DOC, ODT (documents texte), XLSX, XLS, ODS (documents tableur), CSV, ZIP, JPG,
-          PNG et JPG (documents image).
-        </p>
-        <p>
-          Il appartient à l’utilisateur de contrôler l’exactitude du contenu et de la forme des
-          fichiers déposés. L’utilisateur ne pourra ni modifier ni supprimer définitivement les
-          documents déposés. La qualité et la capacité du réseau à la disposition de l’utilisateur
-          peuvent affecter la vitesse de transmission des documents.
-        </p>
-      </div>
-
-      <div>
-        <h4>5. Aide et précaution</h4>
-        <p>
-          En cas de problèmes rencontrés dans l’utilisation de l’application, les utilisateurs
-          peuvent contacter
-          {{ settings.SUPPORT_TEAM_EMAIL|obfuscate_mailto:"la plate-forme d’assistance" }}
-        <p>
-          En cas d’indisponibilité temporaire du service e.contrôle, l’utilisateur peut, s’il est
-          contraint par un délai, transmettre ses documents aux équipe de contrôle par voie papier,
-          par télécopie ou par message électronique adressé à l’adresse de l’équipe de contrôle.
-        <p>
-          Il appartient par ailleurs à l’utilisateur de s’assurer du bon fonctionnement de son
-          matériel et de son réseau. L’utilisateur doit être conscient des limites de sécurité de
-          son poste de travail. Il peut se référer aux bonnes pratiques présentées sur le
-          site
-          <a href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
-             target="_blank"
-             rel="noopener noreferrer">
-            http://www.ssi.gouv.fr/administration/bonnes-pratiques/
-          </a>
-          .
+      <div class="alert alert-primary mb-0">
+        <p class="h4">
+          En utilisant l’application e.contrôle, vous vous engagez à respecter les conditions générales d'utilisation suivantes :
         </p>
       </div>
 
 
-      <div>
-        <h4>6. Données personnelles</h4>
-        <p>
-          L’application e.contrôle est mise en œuvre par la direction des systèmes d’information
-          de la Cour des comptes.
-        <p>
-          Les données recueillies par cette application le sont pour permettre la gestion de
-          l’activité de contrôle des juridictions financières conformément aux dispositions
-          prévues par le code des juridictions financières. Elles sont protégées par le secret de
-          l’instruction. Les juridictions financières s’engagent à prendre toute disposition pour garantir le secret de leurs investigations et la
-          protection des informations transmises. Pour tout renseignement et pour exercer vos
-          droits, vous pouvez prendre contact auprès de la déléguée à la protection des
-          données (DPO) des juridictions financières à l’adresse suivante : dpo-jf[at]ccomptes.fr
-          ou par courrier : Cour des comptes, 13 rue Cambon, 75001 Paris.
-        </p>
-      </div>
+      <div class="text-justify mt-6">
+        {% block subtitle %}
+        {% endblock subtitle %}
+        <div class="scrollbox">
+          <div>
+            <h4>1. Préambule</h4>
+            <p>
+              La Cour des comptes et les Chambres régionales et territoriales des comptes
+              sont habilitées à accéder à tous documents, données et traitements, de quelque
+              nature que ce soit, relatifs à la gestion des services et organismes soumis à leurs
+              contrôles ou nécessaires à l'exercice de leurs attributions, et à se les faire
+              communiquer.
+            </p>
+            <p>
+              Le fait de faire obstacle, de quelque façon que ce soit, à l'exercice des pouvoirs
+              attribués aux membres et personnels de la Cour des comptes, et des Chambres
+              régionales et territoriales des comptes, est puni de 15 000 euros d'amende
+              conformément au code des juridictions financières. Le procureur général près la
+              Cour des comptes peut saisir le parquet près la juridiction compétente en vue de
+              déclencher l'action publique.
+            </p>
+          </div>
 
-      <div>
-        <h4>7. Evolution du service</h4>
-        <p>
-          Nous pouvons faire évoluer e.contrôle sans information préalable ou préavis.
-          Nous ajoutons et améliorons régulièrement l’interface et modifions les formulations sur la base de vos retours, des évolutions réglementaires et législatives, et des mises à jour de sécurité.
-        </p>
-      </div>
+          <div>
+            <h4>2. Caractéristiques techniques</h4>
+            <p>
+              La liaison avec l’application e.contrôle s'effectue au moyen d'un protocole sécurisé
+              depuis le site
+              <a href="https://e-controles-beta.ccomptes.fr/" target="_blank" rel="noopener noreferrer">
+                https://e-controles-beta.ccomptes.fr/
+              </a>
+            </p>
+            <p>
+              L’utilisation d’un navigateur Internet usuel dans une version maintenue par l’éditeur
+              est recommandée pour une utilisation optimale de l’application e.contrôle. L’utilisation
+              de l’application requiert en outre un logiciel permettant la lecture des documents au
+              format PDF (Portable Document Format), DOCX (documentation en format texte) et
+              XLSX (document en format tableau).
+            </p>
+            <p>
+              Les navigateurs utilisés doivent activer JavaScript et accepter les cookies.
+            </p>
+            <p>
+              Chaque utilisateur doit disposer d’une adresse électronique active qui sera liée à son
+              compte personnel. Chaque utilisateur doit s’assurer de conserver cette adresse
+              électronique en fonctionnement. Il peut, le cas échéant, demander son remplacement en
+              sollicitant l’équipe de contrôle.
+            </p>
+          </div>
 
-      <div>
-        <h4>8. Disponilité du service</h4>
-        <p>
-          Nous pouvons suspendre l’accès à e.contrôle sans information préalable ni préavis,
-          notamment pour des raisons de maintenance. Nous mettons e.contrôle à disposition sans
-          garantie sur sa disponibilité. Même si nous nous efforçons de maintenir le service toujours opérationnel,
-          cela signifie que d’éventuelles indisponibilités n’ouvriront pas droit à compensation financière.
-          Nous nous réservons également le droit de bloquer, sans information préalable ni compensation financière,
-          les usages mettant en péril l’utilisation du logiciel par d’autres usagers. Cela nous permet d’anticiper
-          d’éventuelles attaques par déni de service.
-        </p>
-      </div>
+          <div>
+            <h4>3. Identification et sécurité</h4>
+            <p><strong>Identifiant</strong></p>
+            <p>
+              Les agents des juridictions financières sont automatiquement reconnus et authentifiés de
+              manière sécurisée par l'application e.contrôle comme étant des membres internes des
+              juridictions financières.
+            </p>
+            <p>
+              Les agents des organismes interrogés peuvent se connecter à l'application e.contrôle en
+              sollicitant un compte auprès de l'équipe de contrôle.
+            </p>
+            <p>
+              Lors de la création d’un compte e.contrôle, l’identifiant est une adresse électronique.
+            </p>
+            <p>
+              La connexion ne nécessite pas de mot de passe. Elle est réalisée par l’envoi d’un email
+              contenant un lien de connexion unique, temporaire et dont la durée de validité est
+              limitée dans le temps.
+            </p>
+            <p><strong>Traçage et cookies</strong></p>
+            <p>
+              L’application e.contrôle utilise un cookie (témoin de navigation) sur le navigateur du
+              client pour stocker un identifiant de session. Ce cookie ne contient aucune autre
+              information et est rendu invalide à la fin de la session de navigation.
+            </p>
+          </div>
 
-      <div>
-        <h4>9. Evolution des conditions d'utilisation</h4>
-        <p>
-          Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
-          en fonction des modifications apportées au service, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
-          Ces modifications et mises à jour s’imposent à l’utilisateur qui doit, en conséquence, se référer régulièrement à cette rubrique
-          pour vérifier les conditions générales en vigueur.
-        </p>
-      </div>
+          <div>
+            <h4>4. Transfert de documents</h4>
+            <p>Seuls les fichiers en rapport avec les procédures des juridictions financières doivent
+              être chargés dans l’application e.contrôle. Ces fichiers doivent uniquement avoir un
+              contenu qui n'évolue pas (conenu statique) et être non protégés. La taille maximale de chaque fichier est fixée à
+              256 Mo. Les utilisateurs doivent privilégier les formats PDF, DOCX, DOC, ODT (documents texte), XLSX, XLS, ODS (documents tableur), CSV, ZIP, JPG,
+              PNG et JPG (documents image).
+            </p>
+            <p>
+              Il appartient à l’utilisateur de contrôler l’exactitude du contenu et de la forme des
+              fichiers déposés. L’utilisateur ne pourra ni modifier ni supprimer définitivement les
+              documents déposés. La qualité et la capacité du réseau à la disposition de l’utilisateur
+              peuvent affecter la vitesse de transmission des documents.
+            </p>
+          </div>
 
-      <div>
-        <h4>10.Références</h4>
-        <ul>
-          <li>
-            <a href="https://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006070249">
-              Code des juridictions financières et notamment ses articles L141-2 et suivants.
-            </a>
-          </li>
-          <li>
-            <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037085952&categorieLien=id">
-              Loi n° 2018-493 du 20 juin 2018 relative à la protection des données personnelles
-            </a>
-          </li>
-          <li>
-            <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037800506&categorieLien=id">
-              Ordonnance n° 2018-1125 du 12 décembre 2018 prise en application de l'article 32 de la loi n° 2018-493
-              du 20 juin 2018 relative à la protection des données personnelles et portant modification de la
-              loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés et diverses
-              dispositions concernant la protection des données à caractère personnel et notamment son article 52.
-            </a>
-          </li>
-        </ul>
+          <div>
+            <h4>5. Aide et précaution</h4>
+            <p>
+              En cas de problèmes rencontrés dans l’utilisation de l’application, les utilisateurs
+              peuvent contacter
+              {{ settings.SUPPORT_TEAM_EMAIL|obfuscate_mailto:"la plate-forme d’assistance" }}
+            </p>
+            <p>
+              En cas d’indisponibilité temporaire du service e.contrôle, l’utilisateur peut, s’il est
+              contraint par un délai, transmettre ses documents aux équipe de contrôle par voie papier,
+              par télécopie ou par message électronique adressé à l’adresse de l’équipe de contrôle.
+            </p>
+            <p>
+              Il appartient par ailleurs à l’utilisateur de s’assurer du bon fonctionnement de son
+              matériel et de son réseau. L’utilisateur doit être conscient des limites de sécurité de
+              son poste de travail. Il peut se référer aux bonnes pratiques présentées sur le
+              site
+              <a href="http://www.ssi.gouv.fr/administration/bonnes-pratiques/"
+                target="_blank"
+                rel="noopener noreferrer">
+                http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+              </a>
+              .
+            </p>
+          </div>
+
+
+          <div>
+            <h4>6. Données personnelles</h4>
+            <p>
+              L’application e.contrôle est mise en œuvre par la direction des systèmes d’information
+              de la Cour des comptes.
+            </p>
+            <p>
+              Les données recueillies par cette application le sont pour permettre la gestion de
+              l’activité de contrôle des juridictions financières conformément aux dispositions
+              prévues par le code des juridictions financières. Elles sont protégées par le secret de
+              l’instruction. Les juridictions financières s’engagent à prendre toute disposition pour garantir le secret de leurs investigations et la
+              protection des informations transmises. Pour tout renseignement et pour exercer vos
+              droits, vous pouvez prendre contact auprès de la déléguée à la protection des
+              données (DPO) des juridictions financières à l’adresse suivante : dpo-jf[at]ccomptes.fr
+              ou par courrier : Cour des comptes, 13 rue Cambon, 75001 Paris.
+            </p>
+          </div>
+
+          <div>
+            <h4>7. Evolution du service</h4>
+            <p>
+              Nous pouvons faire évoluer e.contrôle sans information préalable ou préavis.
+              Nous ajoutons et améliorons régulièrement l’interface et modifions les formulations sur la base de vos retours, des évolutions réglementaires et législatives, et des mises à jour de sécurité.
+            </p>
+          </div>
+
+          <div>
+            <h4>8. Disponilité du service</h4>
+            <p>
+              Nous pouvons suspendre l’accès à e.contrôle sans information préalable ni préavis,
+              notamment pour des raisons de maintenance. Nous mettons e.contrôle à disposition sans
+              garantie sur sa disponibilité. Même si nous nous efforçons de maintenir le service toujours opérationnel,
+              cela signifie que d’éventuelles indisponibilités n’ouvriront pas droit à compensation financière.
+              Nous nous réservons également le droit de bloquer, sans information préalable ni compensation financière,
+              les usages mettant en péril l’utilisation du logiciel par d’autres usagers. Cela nous permet d’anticiper
+              d’éventuelles attaques par déni de service.
+            </p>
+          </div>
+
+          <div>
+            <h4>9. Evolution des conditions d'utilisation</h4>
+            <p>
+              Les termes des présentes conditions d’utilisation peuvent être modifiés ou complétés à tout moment, sans préavis,
+              en fonction des modifications apportées au service, de l’évolution de la législation ou pour tout autre motif jugé nécessaire.
+              Ces modifications et mises à jour s’imposent à l’utilisateur qui doit, en conséquence, se référer régulièrement à cette rubrique
+              pour vérifier les conditions générales en vigueur.
+            </p>
+          </div>
+
+          <div>
+            <h4>10.Références</h4>
+            <ul>
+              <li>
+                <a href="https://www.legifrance.gouv.fr/affichCode.do?cidTexte=LEGITEXT000006070249">
+                  Code des juridictions financières et notamment ses articles L141-2 et suivants.
+                </a>
+              </li>
+              <li>
+                <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037085952&categorieLien=id">
+                  Loi n° 2018-493 du 20 juin 2018 relative à la protection des données personnelles
+                </a>
+              </li>
+              <li>
+                <a href="https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000037800506&categorieLien=id">
+                  Ordonnance n° 2018-1125 du 12 décembre 2018 prise en application de l'article 32 de la loi n° 2018-493
+                  du 20 juin 2018 relative à la protection des données personnelles et portant modification de la
+                  loi n° 78-17 du 6 janvier 1978 relative à l'informatique, aux fichiers et aux libertés et diverses
+                  dispositions concernant la protection des données à caractère personnel et notamment son article 52.
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+        {% block approval %}
+        {% endblock approval %}
       </div>
     </div>
-    {% block approval %}
-    {% endblock approval %}
+
   </div>
 </div>
-
-{% endblock page_main_container %}
+{% endblock page_main_container_with_sidebar %}

--- a/tos/views.py
+++ b/tos/views.py
@@ -18,4 +18,5 @@ class Welcome(LoginRequiredMixin, FormView):
         return super().form_valid(form)
 
 
+# TOS view is accessible without login.
 tos = TemplateView.as_view(template_name='tos/tos.html')


### PR DESCRIPTION
The TOS (terms of service, at `/cgu`) is accessible without login (this is on purpose, it is linked from the home page). 
But without login, some features break : the sidebar, the FAQ link, the user button at top right.

This PR hides the broken features when the user is not logged in : sidebar, and topbar elements.