### PR TITLE
Make save message visible

### DIFF
--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -119,6 +119,7 @@
     <div class="flex-row justify-content-end mt-2">
       <div v-if="saveMessage.isWaitingForMinDisplayTime || saveMessage.isSaveHappening"
            style="min-height: 1.5rem;">
+        <i class="fas fa-sync-alt mr-2"></i>
         Enregistrement en cours ...
       </div>
       <div v-else

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -117,11 +117,12 @@
       </div>
     </div>
     <div class="flex-row justify-content-end mt-2">
-      <div v-if="isSavingMessageDelayOn || isSaveHappening" class="" style="min-height: 1.5rem;">
+      <div v-if="saveMessage.isWaitingForMinDisplayTime || saveMessage.isSaveHappening"
+           style="min-height: 1.5rem;">
         Enregistrement en cours ...
       </div>
       <div v-else class="text-muted" style="min-height: 1.5rem;">
-        {{ saveMessage }}
+        {{ saveMessage.text }}
       </div>
     </div>
   </div>
@@ -157,6 +158,7 @@ const STATES = {
   CREATING_BODY: 2,
   PREVIEW: 3,
 }
+const SAVING_MESSAGE_MIN_DISPLAY_TIME_MILLIS = 2000
 
 axios.defaults.xsrfCookieName = 'csrftoken'
 axios.defaults.xsrfHeaderName = 'X-CSRFTOKEN'
@@ -179,9 +181,11 @@ export default Vue.extend({
       hasErrors: false,
       STATES: STATES,
       state: STATES.LOADING,
-      saveMessage: '',
-      isSavingMessageDelayOn: false,
-      isSaveHappening: false,
+      saveMessage: {
+        text: '',
+        isWaitingForMinDisplayTime: false,
+        isSaveHappening: false,
+      },
     }
   },
   computed: {
@@ -410,16 +414,15 @@ export default Vue.extend({
       this.saveDraft()
     },
     startSavingMessageDisplay() {
-      const SAVING_MESSAGE_MIN_DISPLAY_TIME_MILLIS = 2000
-      this.isSavingMessageDelayOn = true
+      this.saveMessage.isWaitingForMinDisplayTime = true
       setTimeout(
-        () => { this.isSavingMessageDelayOn = false },
+        () => { this.saveMessage.isWaitingForMinDisplayTime = false },
         SAVING_MESSAGE_MIN_DISPLAY_TIME_MILLIS)
 
-      this.isSaveHappening = true
+      this.saveMessage.isSaveHappening = true
     },
     stopSavingMessageDisplay() {
-      this.isSaveHappening = false
+      this.saveMessage.isSaveHappening = false
     },
     saveDraft() {
       this.currentQuestionnaire.is_draft = true
@@ -430,7 +433,7 @@ export default Vue.extend({
           this.currentQuestionnaire = response.data
           this.emitQuestionnaireUpdated()
 
-          this.saveMessage = 'Enregistrement fait à ' + nowTimeString() + '.'
+          this.saveMessage.text = 'Enregistrement fait à ' + nowTimeString() + '.'
           this.stopSavingMessageDisplay()
           return response.data
         })

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -413,7 +413,7 @@ export default Vue.extend({
       }
       this.saveDraft()
     },
-    startSavingMessageDisplay() {
+    displaySaveInProgress() {
       this.saveMessage.isWaitingForMinDisplayTime = true
       setTimeout(
         () => { this.saveMessage.isWaitingForMinDisplayTime = false },
@@ -421,20 +421,20 @@ export default Vue.extend({
 
       this.saveMessage.isSaveHappening = true
     },
-    stopSavingMessageDisplay() {
+    displaySavingDone(dateDone) {
+      this.saveMessage.text = 'Enregistrement fait à ' + dateDone + '.'
       this.saveMessage.isSaveHappening = false
     },
     saveDraft() {
       this.currentQuestionnaire.is_draft = true
-      this.startSavingMessageDisplay()
+      this.displaySaveInProgress()
       return this._doSave()
         .then((response) => {
           console.log('Successful draft save.')
           this.currentQuestionnaire = response.data
           this.emitQuestionnaireUpdated()
 
-          this.saveMessage.text = 'Enregistrement fait à ' + nowTimeString() + '.'
-          this.stopSavingMessageDisplay()
+          this.displaySavingDone(nowTimeString())
           return response.data
         })
         .catch((error) => {

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -117,7 +117,10 @@
       </div>
     </div>
     <div class="flex-row justify-content-end mt-2">
-      <div class="text-muted" style="min-height: 1.5rem;">
+      <div v-if="isSavingMessageDelayOn || isSaveHappening" class="" style="min-height: 1.5rem;">
+        Enregistrement en cours ...
+      </div>
+      <div v-else class="text-muted" style="min-height: 1.5rem;">
         {{ saveMessage }}
       </div>
     </div>
@@ -177,6 +180,8 @@ export default Vue.extend({
       STATES: STATES,
       state: STATES.LOADING,
       saveMessage: '',
+      isSavingMessageDelayOn: false,
+      isSaveHappening: false,
     }
   },
   computed: {
@@ -353,9 +358,6 @@ export default Vue.extend({
       this.errors = []
       this.errorMessage = ''
     },
-    clearSaveMessage() {
-      this.saveMessage = ''
-    },
     _doSave() {
       const cleanPreSave = () => {
         if (this.currentQuestionnaire.end_date) {
@@ -407,15 +409,29 @@ export default Vue.extend({
       }
       this.saveDraft()
     },
+    startSavingMessageDisplay() {
+      const SAVING_MESSAGE_MIN_DISPLAY_TIME_MILLIS = 2000
+      this.isSavingMessageDelayOn = true
+      setTimeout(
+        () => { this.isSavingMessageDelayOn = false },
+        SAVING_MESSAGE_MIN_DISPLAY_TIME_MILLIS)
+
+      this.isSaveHappening = true
+    },
+    stopSavingMessageDisplay() {
+      this.isSaveHappening = false
+    },
     saveDraft() {
       this.currentQuestionnaire.is_draft = true
+      this.startSavingMessageDisplay()
       return this._doSave()
         .then((response) => {
           console.log('Successful draft save.')
           this.currentQuestionnaire = response.data
           this.emitQuestionnaireUpdated()
 
-          this.saveMessage = 'Votre dernière sauvegarde a eu lieu à ' + nowTimeString() + '.'
+          this.saveMessage = 'Enregistrement fait à ' + nowTimeString() + '.'
+          this.stopSavingMessageDisplay()
           return response.data
         })
         .catch((error) => {

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -123,8 +123,10 @@
       </div>
       <div v-else
            :class="{ 'text-danger': hasErrors, 'text-muted': !hasErrors }"
+           class="flex-row align-items-center"
            style="min-height: 1.5rem;">
         <i v-if="hasErrors" class="fe fe-alert-triangle mr-2"></i>
+        <i v-else class="fe fe-check-circle mr-2"></i>
         {{ saveMessage.text }}
       </div>
     </div>

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -121,7 +121,10 @@
            style="min-height: 1.5rem;">
         Enregistrement en cours ...
       </div>
-      <div v-else class="text-muted" style="min-height: 1.5rem;">
+      <div v-else
+           :class="{ 'text-danger': hasErrors, 'text-muted': !hasErrors }"
+           style="min-height: 1.5rem;">
+        <i v-if="hasErrors" class="fe fe-alert-triangle mr-2"></i>
         {{ saveMessage.text }}
       </div>
     </div>
@@ -425,6 +428,12 @@ export default Vue.extend({
       this.saveMessage.text = 'Enregistrement fait à ' + dateDone + '.'
       this.saveMessage.isSaveHappening = false
     },
+    displaySavingDoneWithError() {
+      this.saveMessage.text =
+        'Erreur lors de la sauvegarde : les modifications ne sont pas enregistrées.'
+      this.saveMessage.isWaitingForMinDisplayTime = false
+      this.saveMessage.isSaveHappening = false
+    },
     saveDraft() {
       this.currentQuestionnaire.is_draft = true
       this.displaySaveInProgress()
@@ -442,6 +451,7 @@ export default Vue.extend({
           const errorToDisplay =
             (error.response && error.response.data) ? error.response.data : error
           this.displayErrors('Erreur lors de la sauvegarde du brouillon.', errorToDisplay)
+          this.displaySavingDoneWithError()
         })
     },
     startPublishFlow() {


### PR DESCRIPTION
Save message was not visible enough for users to notice when the save had failed. This caused some loss of data in the past. (issue : https://github.com/betagouv/e-controle/issues/222 and https://github.com/betagouv/e-controle/issues/237)

This PR displays a "saving..." message for 2 seconds at least (so that users have time to see the message) and then a success or error message. This is copied from what google docs does.

Saving : 
![Screen Shot 2020-07-31 at 15 31 06](https://user-images.githubusercontent.com/911434/89039755-e74b5e80-d342-11ea-926e-98349ead0430.png)

Done with success : 
![Screen Shot 2020-07-31 at 15 30 51](https://user-images.githubusercontent.com/911434/89039757-e7e3f500-d342-11ea-80f5-e9044a500c86.png)

Done with error : 
![Screen Shot 2020-07-31 at 15 30 39](https://user-images.githubusercontent.com/911434/89039761-e87c8b80-d342-11ea-8977-52ec6b65dd07.png)

Errors are not fully displayed in the save message, because they are already displayed in the error bar at the top of the page (but that's debateable, we could display them)
