### PR TITLE
Less email input errors : warning for inspector email ending

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -42,6 +42,10 @@ export EMAIL_SPACING_TIME_MILLIS=5000
 
 #export SUPPORT_TEAM_EMAIL=support@e-controle.fr
 
+# The user will get a warning when trying to add an inspector whose email doesn't end with EXPECTED_INSPECTOR_EMAIL_ENDINGS.
+# If you leave it empty, all domains will be accepted.
+export EXPECTED_INSPECTOR_EMAIL_ENDINGS=@ccomptes.fr,@crtc.ccomptes.fr
+
 # Send email notification when changing users
 #export SEND_EMAIL_WHEN_USER_ADDED=True
 #export SEND_EMAIL_WHEN_USER_REMOVED=True

--- a/config/api_views.py
+++ b/config/api_views.py
@@ -9,9 +9,10 @@ class ConfigViewSet(viewsets.ViewSet):
 
     def list(self, request):
         config = {
-            'support_team_email': settings.SUPPORT_TEAM_EMAIL,
+            'expected_inspector_email_endings': settings.EXPECTED_INSPECTOR_EMAIL_ENDINGS,
+            'site_url': f'https://{get_current_site(request).domain}',
             'static_files_url': settings.STATIC_URL,
-            'site_url': f'https://{get_current_site(request).domain}'
+            'support_team_email': settings.SUPPORT_TEAM_EMAIL
         }
         if request.user.profile.is_inspector:
             config.update({

--- a/ecc/settings.py
+++ b/ecc/settings.py
@@ -200,6 +200,9 @@ EMAIL_USE_SSL = env('EMAIL_USE_SSL')
 # Time we wait in between emails, to space them out and avoid going over our allowed email quota
 EMAIL_SPACING_TIME_MILLIS = env('EMAIL_SPACING_TIME_MILLIS', default=10000)
 
+# The user will get a warning when trying to add an inspector whose email doesn't end with EXPECTED_INSPECTOR_EMAIL_ENDINGS
+EXPECTED_INSPECTOR_EMAIL_ENDINGS=env('EXPECTED_INSPECTOR_EMAIL_ENDINGS', default='')
+
 SEND_EMAIL_WHEN_USER_ADDED = env('SEND_EMAIL_WHEN_USER_ADDED', default=False)
 SEND_EMAIL_WHEN_USER_REMOVED = env('SEND_EMAIL_WHEN_USER_REMOVED', default=False)
 

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -96,7 +96,10 @@
           </fieldset>
           <div class="flex-row justify-content-between">
             <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
-            <button type="submit" class="btn btn-primary">Ajouter</button>
+            <div class="text-right">
+              <button type="button" class="btn btn-secondary" @click="back">Retour</button>
+              <button type="submit" class="btn btn-primary">Ajouter</button>
+            </div>
           </div>
         </form>
 

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -61,9 +61,11 @@
               .
             </div>
             <div> Cet email ne finit pas par
-              <strong>@ccomptes.fr</strong>
-              ou
-              <strong>@crtc.ccomptes.fr</strong>
+              <template v-for="(ending, index) in expectedEndingsArray">
+                <strong>{{ ending }}</strong>
+                <span v-if="index < expectedEndingsArray.length - 2">,</span>
+                <span v-if="index === expectedEndingsArray.length - 2" class="mr-1">ou</span>
+              </template>
               .
             </div>
           </div>
@@ -186,12 +188,14 @@ export default Vue.extend({
       searchResult: {},
       foundUser: false,
       stepShown: 1,
+      expectedEndingsArray: [],
     }
   },
   computed: {
     ...mapFields([
       'editingControl',
       'editingProfileType',
+      'config.expected_inspector_email_endings',
       'config.site_url',
     ]),
     emailBody: function() {
@@ -253,11 +257,16 @@ export default Vue.extend({
       }
     },
     validateEmail() {
+      const expectedEndingsArray = this.expected_inspector_email_endings.split(',')
       const isInspectorEmail = email => {
-        return email.endsWith('@ccomptes.fr') || email.endsWith('@crtc.ccomptes.fr')
+        // At least one ending should match.
+        return expectedEndingsArray.some(ending => {
+          return email.endsWith(ending)
+        })
       }
 
       if (this.editingProfileType === 'inspector' && !isInspectorEmail(this.formData.email)) {
+        this.expectedEndingsArray = expectedEndingsArray
         this.stepShown = 1.5
       } else {
         this.findUser()

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -8,7 +8,7 @@
       </div>
       <div class="modal-body">
         <div v-if="hasErrors" class="alert alert-danger">
-          L'ajout d'utilisateur n'a pas fonctionné.
+          L'ajout d'utilisateur n'a pas fonctionné. Vous pouvez réessayer.
         </div>
         <div v-if="editingProfileType==='inspector'" class="text-center">
             <h4><i class="fa fa-university mr-2"></i><strong>Équipe de contrôle</strong></h4>
@@ -38,8 +38,8 @@
               </p>
             </div>
           </div>
-          <div class="text-right">
-            <button type="button" class="btn btn-secondary" @click="hideThisModal">Annuler</button>
+          <div class="flex-row justify-content-between">
+            <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
             <button type="submit" class="btn btn-primary">Suivant</button>
           </div>
         </form>
@@ -48,7 +48,11 @@
           <div class="alert alert-warning alert-icon my-8">
             <i class="fa fa-exclamation-circle mr-2" aria-hidden="true"></i>
             <div class="mb-4">
-              Vous allez ajouter <strong>{{ formData.email }}</strong> comme contrôleur.
+              Vous allez ajouter
+              <strong>{{ formData.email }}</strong>
+              comme
+              <strong>contrôleur</strong>
+              .
             </div>
             <div> Cet email ne finit pas par
               <strong>@ccomptes.fr</strong>
@@ -57,13 +61,16 @@
               .
             </div>
           </div>
-          <div class="text-right">
-            <button type="button" class="btn btn-secondary" @click="back">
-              C'est une erreur, Retour
-            </button>
-            <button type="submit" class="btn btn-primary">
-              C'est volontaire, Suivant
-            </button>
+          <div class="flex-row justify-content-between">
+            <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
+            <div class="text-right">
+              <button type="button" class="btn btn-secondary" @click="back">
+                C'est une erreur,<br/>Retour
+              </button>
+              <button type="submit" class="btn btn-primary">
+                C'est volontaire,<br/>Suivant
+              </button>
+            </div>
           </div>
         </form>
 
@@ -87,8 +94,8 @@
               <p class="text-muted pl-2" v-if="errors.last_name"><i class="fa fa-warning"></i> {{ errors.last_name.join(' / ')}}</p>
             </div>
           </fieldset>
-          <div class="text-right">
-            <button type="button" class="btn btn-secondary" @click="hideThisModal">Annuler</button>
+          <div class="flex-row justify-content-between">
+            <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
             <button type="submit" class="btn btn-primary">Ajouter</button>
           </div>
         </form>
@@ -109,7 +116,7 @@
           </div>
 
           <div class="mt-5 flex-row justify-content-end">
-            <button type="button" class="btn btn-secondary" @click="hideThisModal">
+            <button type="button" class="btn btn-secondary" @click="cancel">
               Je l'ai informé.e
             </button>
             <a class="btn btn-primary ml-2"
@@ -192,7 +199,7 @@ export default Vue.extend({
     },
   },
   methods: {
-    hideThisModal() {
+    cancel() {
       this.resetFormData()
       $('#addUserModal').modal('hide')
     },

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -17,7 +17,7 @@
             <h4><i class="fa fa-building mr-2"></i><strong>Organisme interrogé</strong></h4>
         </div>
 
-        <form @submit.prevent="findUser" v-if="stepShown === 1" @keydown.esc="resetFormData">
+        <form @submit.prevent="validateEmail" v-if="stepShown === 1" @keydown.esc="resetFormData">
           <div class="form-fieldset">
             <div class="form-group">
               <label id="email-label" class="form-label">
@@ -40,6 +40,23 @@
           </div>
           <div class="text-right">
             <button type="button" class="btn btn-secondary" @click="hideThisModal">Annuler</button>
+            <button type="submit" class="btn btn-primary">Suivant</button>
+          </div>
+        </form>
+
+        <form @submit.prevent="findUser" v-if="stepShown === 1.5" @keydown.esc="resetFormData">
+          <div>
+            Vous allez ajouter un contrôleur dont l'email ne finit pas par
+            <strong>@ccomptes.fr</strong>
+            ou
+            <strong>@crtc.ccomptes.fr</strong>
+            . Etes-vous sûr.e ?
+          </div>
+          <div>
+            {{ formData.email }}
+          </div>
+          <div class="text-right">
+            <button type="button" class="btn btn-secondary" @click="back">Retour</button>
             <button type="submit" class="btn btn-primary">Suivant</button>
           </div>
         </form>
@@ -185,6 +202,32 @@ export default Vue.extend({
       this.foundUser = false
       this.hasErrors = false
       this.errors = []
+    },
+    back() {
+      switch (this.stepShown) {
+        case 1.5:
+          this.stepShown = 1
+          break
+        case 2:
+          this.stepShown = 1
+          break
+        case 3:
+          this.stepShown = 2
+          break
+        default:
+          break
+      }
+    },
+    validateEmail() {
+      const isInspectorEmail = email => {
+        return email.endsWith('@ccomptes.fr') || email.endsWith('@crtc.ccomptes.fr')
+      }
+
+      if (this.editingProfileType === 'inspector' && !isInspectorEmail(this.formData.email)) {
+        this.stepShown = 1.5
+      } else {
+        this.findUser()
+      }
     },
     addUser() {
       this.formData.control = this.editingControl.id

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -45,19 +45,25 @@
         </form>
 
         <form @submit.prevent="findUser" v-if="stepShown === 1.5" @keydown.esc="resetFormData">
-          <div>
-            Vous allez ajouter un contrôleur dont l'email ne finit pas par
-            <strong>@ccomptes.fr</strong>
-            ou
-            <strong>@crtc.ccomptes.fr</strong>
-            . Etes-vous sûr.e ?
-          </div>
-          <div>
-            {{ formData.email }}
+          <div class="alert alert-warning alert-icon">
+            <i class="fa fa-exclamation-circle mr-2" aria-hidden="true"></i>
+            <div class="mb-4">
+              Vous allez ajouter <strong>{{ formData.email }}</strong> comme contrôleur.
+            </div>
+            <div> Cet email ne finit pas par
+              <strong>@ccomptes.fr</strong>
+              ou
+              <strong>@crtc.ccomptes.fr</strong>
+              .
+            </div>
           </div>
           <div class="text-right">
-            <button type="button" class="btn btn-secondary" @click="back">Retour</button>
-            <button type="submit" class="btn btn-primary">Suivant</button>
+            <button type="button" class="btn btn-secondary" @click="back">
+              C'est une erreur, Retour
+            </button>
+            <button type="submit" class="btn btn-primary">
+              C'est volontaire, Suivant
+            </button>
           </div>
         </form>
 

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -25,6 +25,8 @@
                 <span class="form-required"></span>
               </label>
               <input type="email"
+                     autocapitalize=off
+                     autocorrect=off
                      class="form-control"
                      v-bind:class="{ 'state-invalid': errors.email }"
                      v-model="formData.email"

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -45,7 +45,7 @@
         </form>
 
         <form @submit.prevent="findUser" v-if="stepShown === 1.5" @keydown.esc="resetFormData">
-          <div class="alert alert-warning alert-icon">
+          <div class="alert alert-warning alert-icon my-8">
             <i class="fa fa-exclamation-circle mr-2" aria-hidden="true"></i>
             <div class="mb-4">
               Vous allez ajouter <strong>{{ formData.email }}</strong> comme contrôleur.

--- a/static/src/users/AddUserModal.vue
+++ b/static/src/users/AddUserModal.vue
@@ -39,8 +39,14 @@
             </div>
           </div>
           <div class="flex-row justify-content-between">
-            <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
-            <button type="submit" class="btn btn-primary">Suivant</button>
+            <button type="button" class="btn btn-secondary" @click="cancel">
+              <i class="fa fa-times mr-2"></i>
+              Annuler
+            </button>
+            <button type="submit" class="btn btn-primary">
+              Suivant
+              <i class="fa fa-chevron-right ml-2"></i>
+            </button>
           </div>
         </form>
 
@@ -62,13 +68,19 @@
             </div>
           </div>
           <div class="flex-row justify-content-between">
-            <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
+            <button type="button" class="btn btn-secondary" @click="cancel">
+              <i class="fa fa-times mr-2"></i>
+              Annuler
+            </button>
             <div class="text-right">
               <button type="button" class="btn btn-secondary" @click="back">
-                C'est une erreur,<br/>Retour
+                C'est une erreur,<br/>
+                <i class="fa fa-chevron-left mr-2"></i>
+                Retour
               </button>
               <button type="submit" class="btn btn-primary">
                 C'est volontaire,<br/>Suivant
+                <i class="fa fa-chevron-right ml-2"></i>
               </button>
             </div>
           </div>
@@ -95,9 +107,15 @@
             </div>
           </fieldset>
           <div class="flex-row justify-content-between">
-            <button type="button" class="btn btn-secondary" @click="cancel">Annuler</button>
+            <button type="button" class="btn btn-secondary" @click="cancel">
+              <i class="fa fa-times mr-2"></i>
+              Annuler
+            </button>
             <div class="text-right">
-              <button type="button" class="btn btn-secondary" @click="back">Retour</button>
+              <button type="button" class="btn btn-secondary" @click="back">
+                <i class="fa fa-chevron-left mr-2"></i>
+                Retour
+              </button>
               <button type="submit" class="btn btn-primary">Ajouter</button>
             </div>
           </div>


### PR DESCRIPTION
Add a verification step when adding a new inspector user : if the email doesn't end with one of the expected endings, show a warning. 
There should be no changes for audited users.

![Screen Shot 2020-09-23 at 18 41 04](https://user-images.githubusercontent.com/911434/94042880-62be0f00-fdcc-11ea-984e-d824defb2248.png)

Edit : also includes cleaning up the navigation buttons (suivant, retour, annuler)