### PR TITLE
Add questionnaire modal to send confirmation email

### DIFF
--- a/static/src/questionnaires/PublishFlow.vue
+++ b/static/src/questionnaires/PublishFlow.vue
@@ -88,11 +88,20 @@
           Bravo, votre questionnaire est publié!
         </h4>
         <div class="mt-5">
-            Pensez à informer l'organisme contrôlé.
+            <p>Pensez à informer l'organisme contrôlé.</p>
+            <p>Si des réponses sont déposées par l'organisme interrogé, vous recevrez un email de
+          notification dès le lendemain 8 heures.</p>
         </div>
       </div>
       <div class="modal-body text-center">
-        <div class="mt-5 flex-row justify-content-end">
+        <div class="mt-5 flex-row justify-content-center">
+          <button type="button"
+            class="btn btn-primary ml-2"
+            @click="goHome"
+          >
+            <i class="fa fa-chevron-left mr-2"></i>
+            Revenir à l'accueil
+          </button>
           <a class="btn btn-primary ml-2"
               :href="'mailto:' +
                     '?subject=Questionnaire publié' +
@@ -103,19 +112,6 @@
             Créer un mail pour l'informer
           </a>
         </div>
-        <p>
-          Si des réponses sont déposées par l'organisme interrogé, vous recevrez un email de
-          notification dès le lendemain 8 heures.
-        </p>
-      </div>
-      <div class="modal-footer border-top-0 d-flex justify-content-center">
-        <button type="button"
-                class="btn btn-primary"
-                @click="goHome"
-        >
-          <i class="fa fa-chevron-left mr-2"></i>
-          Revenir à l'accueil
-        </button>
       </div>
     </template>
 
@@ -134,7 +130,7 @@ export default Vue.extend({
     ModalFlow,
   },
   props: {
-    controlId: Number,
+    questionnaire: Object,
     publishFunction: Function,
     // Pass window dependency for testing
     window: {
@@ -149,10 +145,12 @@ export default Vue.extend({
       controls: 'controls',
     }),
     emailBody: function() {
-      const currentControl = this.controls.find(control => control.id === this.controlId)
+      const currentControl = this.controls.find(control => control.id === this.questionnaire.control)
+      const expiryDateString = this.questionnaire.end_date === null ? '' : ' La date limite de réponse est le' + this.questionnaire.end_date + '.'
 
       if (currentControl) {
-        return 'Je viens de publier un questionnaire au contrôle ' + currentControl.title + '. Il est désormais disponible sur la plate-forme e-contrôle.'
+        const newline = '%0d%0a'
+        return `Bonjour,${newline}${newline}Un nouveau questionnaire vient d'être ajouté au contrôle ${currentControl.title}. Il s'agit du questionnaire numéro ${this.questionnaire.id} : ${this.questionnaire.title}.${expiryDateString}${newline}${newline}Nous vous invitons à vous connecter à e-contrôle pour le voir, au lien ci-dessous :${newline}${newline}https://e-controle-beta.ccomptes.fr${newline}${newline}Cordialement,`
       }
 
       return ''
@@ -164,7 +162,7 @@ export default Vue.extend({
       this.$refs.modalFlow.start()
     },
     goHome() {
-      this.window.location.href = backend['control-detail'](this.controlId)
+      this.window.location.href = backend['control-detail'](this.questionnaire.control)
     },
   },
 })

--- a/static/src/questionnaires/PublishFlow.vue
+++ b/static/src/questionnaires/PublishFlow.vue
@@ -87,8 +87,22 @@
         <h4 class="text-center">
           Bravo, votre questionnaire est publié!
         </h4>
+        <div class="mt-5">
+            Pensez à informer l'organisme contrôlé.
+        </div>
       </div>
       <div class="modal-body text-center">
+        <div class="mt-5 flex-row justify-content-end">
+          <a class="btn btn-primary ml-2"
+              :href="'mailto:' +
+                    '?subject=Questionnaire publié' +
+                    '&body=' + emailBody"
+              target="_blank"
+              rel="noopener noreferrer"
+          >
+            Créer un mail pour l'informer
+          </a>
+        </div>
         <p>
           Si des réponses sont déposées par l'organisme interrogé, vous recevrez un email de
           notification dès le lendemain 8 heures.
@@ -111,6 +125,7 @@
 <script>
 import backend from '../utils/backend'
 import { mapFields } from 'vuex-map-fields'
+import { mapState } from 'vuex'
 import ModalFlow from '../utils/ModalFlow'
 import Vue from 'vue'
 
@@ -130,6 +145,18 @@ export default Vue.extend({
     ...mapFields([
       'config',
     ]),
+    ...mapState({
+      controls: 'controls',
+    }),
+    emailBody: function() {
+      const currentControl = this.controls.find(control => control.id === this.controlId)
+
+      if (currentControl) {
+        return 'Je viens de publier un questionnaire au contrôle ' + currentControl.title + '. Il est désormais disponible sur la plate-forme e-contrôle.'
+      }
+
+      return ''
+    },
   },
   methods: {
     start() {

--- a/static/src/questionnaires/QuestionnaireCreate.vue
+++ b/static/src/questionnaires/QuestionnaireCreate.vue
@@ -135,7 +135,7 @@
 
   <publish-flow ref="publishFlow"
                 :publishFunction="publish"
-                :controlId="currentQuestionnaire.control">
+                :questionnaire="currentQuestionnaire">
   </publish-flow>
 
 </div>


### PR DESCRIPTION
Adds a step to the questionnaire modal with pre-filled email for controlled organisms.