### PR TITLE
Add character limit to cloned questionnaire

### DIFF
--- a/static/src/controls/ControlTitle.vue
+++ b/static/src/controls/ControlTitle.vue
@@ -26,9 +26,14 @@
                    class="form-control"
                    v-model="reference_code"
                    required aria-labelledby="reference-label"
-                   maxlength="255"
+                   maxlength="25"
+                   title="Ce champ ne doit pas contenir de caractères spéciaux
+                         ( ! , @ # $ / \ ' &quot; + etc)"
                    @focus="referenceChanged">
           </div>
+          <span class="text-danger" v-if="reference_code.length > 24">
+            Ce champ ne peut contenir plus de 25 caractères.
+          </span>
         </div>
         <div class="form-group mb-6">
           <label class="custom-control custom-checkbox">


### PR DESCRIPTION
Add a limit of 25 characters to newly cloned questionnaire reference codes